### PR TITLE
Strong Types on `rows` and `columns` 

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -755,7 +755,7 @@ dependencies = [
 
 [[package]]
 name = "da-primitives"
-version = "0.2.2"
+version = "0.2.3"
 dependencies = [
  "beefy-merkle-tree",
  "derive_more",
@@ -1648,6 +1648,7 @@ dependencies = [
  "bls12_381",
  "criterion",
  "da-primitives",
+ "derive_more",
  "dusk-bytes",
  "dusk-plonk",
  "frame-support",
@@ -1689,6 +1690,7 @@ dependencies = [
 name = "kate-recovery"
 version = "0.2.0"
 dependencies = [
+ "derive_more",
  "dusk-bytes",
  "dusk-plonk",
  "getrandom 0.2.7",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1643,7 +1643,7 @@ dependencies = [
 
 [[package]]
 name = "kate"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "bls12_381",
  "criterion",
@@ -1688,7 +1688,7 @@ dependencies = [
 
 [[package]]
 name = "kate-recovery"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "derive_more",
  "dusk-bytes",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1668,6 +1668,7 @@ dependencies = [
  "rand_core 0.5.1",
  "rayon",
  "serde",
+ "serde_json",
  "sp-core",
  "sp-std",
  "static_assertions",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,4 +15,3 @@ sp-std = { git = "https://github.com/paritytech/substrate.git", branch = "polkad
 sp-runtime = { git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.13" }
 sp-runtime-interface = { git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.13" }
 frame-support = { git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.13" }
-

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,3 +15,4 @@ sp-std = { git = "https://github.com/paritytech/substrate.git", branch = "polkad
 sp-runtime = { git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.13" }
 sp-runtime-interface = { git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.13" }
 frame-support = { git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.13" }
+

--- a/kate/Cargo.toml
+++ b/kate/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "kate"
-version = "0.4.0"
+version = "0.5.0"
 authors = ["Denis Ermolin <denis.ermolin@matic.network>"]
 edition = "2021"
 

--- a/kate/Cargo.toml
+++ b/kate/Cargo.toml
@@ -25,6 +25,7 @@ rayon = { version = "1.5.0", optional = true }
 serde = { version = "1.0.121", optional = true, features = ["derive"] }
 sp-core = { version = "4.0.0-dev", default-features = false }
 sp-std = { version = "4.0.0-dev", default-features = false }
+derive_more = "0.99.17"
 static_assertions = "1.1.0"
 
 [dev-dependencies]

--- a/kate/Cargo.toml
+++ b/kate/Cargo.toml
@@ -35,6 +35,7 @@ hex-literal = "0.3.4"
 itertools = "0.10.3"
 kate-proof = { path = "proof", default-features = false }
 proptest = "1.0.0"
+serde_json = "1.0"
 test-case = "1.2.3"
 
 [features]

--- a/kate/Cargo.toml
+++ b/kate/Cargo.toml
@@ -10,6 +10,7 @@ edition = "2021"
 bls12_381 = { version = "0.3.1", optional = true }
 codec = { package = "parity-scale-codec", version = "3.0.0", default-features = false, features = ["derive"] }
 da-primitives = { path = "../primitives/avail", default-features = false }
+derive_more = "0.99.17"
 dusk-bytes = { version = "0.1.6", default-features = false, optional = true }
 dusk-plonk = { git = "https://github.com/maticnetwork/plonk.git", tag = "v0.12.0-polygon-1", optional = true }
 frame-support = { version = "4.0.0-dev", default-features = false }
@@ -25,7 +26,6 @@ rayon = { version = "1.5.0", optional = true }
 serde = { version = "1.0.121", optional = true, features = ["derive"] }
 sp-core = { version = "4.0.0-dev", default-features = false }
 sp-std = { version = "4.0.0-dev", default-features = false }
-derive_more = "0.99.17"
 static_assertions = "1.1.0"
 
 [dev-dependencies]

--- a/kate/benches/kzg.rs
+++ b/kate/benches/kzg.rs
@@ -1,5 +1,5 @@
 use criterion::{black_box, criterion_group, criterion_main, Criterion};
-use da_primitives::{asdr::AppExtrinsic, BlockLenghtColumns, BlockLenghtRows};
+use da_primitives::{asdr::AppExtrinsic, BlockLengthColumns, BlockLengthRows};
 use itertools::Itertools;
 use kate::{
 	com::{build_proof, par_build_commitments, Cell},
@@ -82,8 +82,8 @@ fn bench_par_build_commitments(c: &mut Criterion) {
 			|b| {
 				b.iter(|| {
 					let (_, _, _, _) = par_build_commitments(
-						black_box(BlockLenghtRows(dim.0)),
-						black_box(BlockLenghtColumns(dim.1)),
+						black_box(BlockLengthRows(dim.0)),
+						black_box(BlockLengthColumns(dim.1)),
 						black_box(CHUNK),
 						black_box(&txs),
 						black_box(seed),
@@ -113,11 +113,11 @@ fn bench_build_proof(c: &mut Criterion) {
 		let tx = AppExtrinsic::from(data.to_vec());
 		let txs = [tx];
 
-		let public_params = crate::testnet::public_params(BlockLenghtColumns(dim.1));
+		let public_params = crate::testnet::public_params(BlockLengthColumns(dim.1));
 
 		let (_, _, dims, mat) = par_build_commitments(
-			BlockLenghtRows(dim.0),
-			BlockLenghtColumns(dim.1),
+			BlockLengthRows(dim.0),
+			BlockLengthColumns(dim.1),
 			CHUNK,
 			&txs,
 			seed,
@@ -134,8 +134,8 @@ fn bench_build_proof(c: &mut Criterion) {
 			|b| {
 				b.iter(|| {
 					let cell = Cell::new(
-						BlockLenghtRows(rng.next_u32() % dims.rows.0),
-						BlockLenghtColumns(rng.next_u32() % dims.cols.0),
+						BlockLengthRows(rng.next_u32() % dims.rows.0),
+						BlockLengthColumns(rng.next_u32() % dims.cols.0),
 					);
 
 					let proof = build_proof(&public_params, dims, &mat, &[cell]).unwrap();
@@ -164,19 +164,19 @@ fn bench_verify_proof(c: &mut Criterion) {
 		let tx = AppExtrinsic::from(data.to_vec());
 		let txs = [tx];
 
-		let pp = crate::testnet::public_params(BlockLenghtColumns(dim.1));
+		let pp = crate::testnet::public_params(BlockLengthColumns(dim.1));
 
 		let (_, comms, dims, mat) = par_build_commitments(
-			BlockLenghtRows(dim.0),
-			BlockLenghtColumns(dim.1),
+			BlockLengthRows(dim.0),
+			BlockLengthColumns(dim.1),
 			CHUNK,
 			&txs,
 			seed,
 		)
 		.unwrap();
 
-		let row = BlockLenghtRows(rng.next_u32() % dims.rows.0);
-		let col = BlockLenghtColumns(rng.next_u32() % dims.cols.0);
+		let row = BlockLengthRows(rng.next_u32() % dims.rows.0);
+		let col = BlockLengthColumns(rng.next_u32() % dims.cols.0);
 
 		let proof = build_proof(&pp, dims, &mat, &[Cell { row, col }]).unwrap();
 		assert_eq!(proof.len(), 80);

--- a/kate/benches/kzg.rs
+++ b/kate/benches/kzg.rs
@@ -84,7 +84,7 @@ fn bench_par_build_commitments(c: &mut Criterion) {
 					let (_, _, _, _) = par_build_commitments(
 						black_box(BlockLengthRows(dim.0)),
 						black_box(BlockLengthColumns(dim.1)),
-						black_box(CHUNK),
+						black_box(CHUNK.try_into().unwrap()),
 						black_box(&txs),
 						black_box(seed),
 					)
@@ -118,7 +118,7 @@ fn bench_build_proof(c: &mut Criterion) {
 		let (_, _, dims, mat) = par_build_commitments(
 			BlockLengthRows(dim.0),
 			BlockLengthColumns(dim.1),
-			CHUNK,
+			CHUNK.try_into().unwrap(),
 			&txs,
 			seed,
 		)
@@ -169,7 +169,7 @@ fn bench_verify_proof(c: &mut Criterion) {
 		let (_, comms, dims, mat) = par_build_commitments(
 			BlockLengthRows(dim.0),
 			BlockLengthColumns(dim.1),
-			CHUNK,
+			CHUNK.try_into().unwrap(),
 			&txs,
 			seed,
 		)

--- a/kate/benches/kzg.rs
+++ b/kate/benches/kzg.rs
@@ -1,5 +1,5 @@
 use criterion::{black_box, criterion_group, criterion_main, Criterion};
-use da_primitives::asdr::AppExtrinsic;
+use da_primitives::{asdr::AppExtrinsic, BlockLenghtColumns, BlockLenghtRows};
 use itertools::Itertools;
 use kate::{
 	com::{build_proof, par_build_commitments, Cell},
@@ -10,7 +10,7 @@ use kate_proof::kc_verify_proof;
 use rand::prelude::*;
 use rand_chacha::ChaCha20Rng;
 
-fn variate_rc(rows: usize, cols: usize) -> Vec<(usize, usize)> {
+fn variate_rc(rows: u32, cols: u32) -> Vec<(u32, u32)> {
 	assert_eq!(rows >= 64, true);
 	assert_eq!(cols >= 64, true);
 
@@ -31,12 +31,12 @@ fn variate_rc(rows: usize, cols: usize) -> Vec<(usize, usize)> {
 	dims
 }
 
-fn generate_matrix_dimensions() -> Vec<(usize, usize)> {
-	const MIN_ROWS: usize = 256;
-	const MAX_ROWS: usize = 2048;
+fn generate_matrix_dimensions() -> Vec<(u32, u32)> {
+	const MIN_ROWS: u32 = 256;
+	const MAX_ROWS: u32 = 2048;
 
-	const MIN_COLS: usize = 256;
-	const MAX_COLS: usize = 2048;
+	const MIN_COLS: u32 = 256;
+	const MAX_COLS: u32 = 2048;
 
 	let mut dims = Vec::new();
 
@@ -50,7 +50,7 @@ fn generate_matrix_dimensions() -> Vec<(usize, usize)> {
 		r <<= 1;
 	}
 
-	dims.into_iter().unique().collect::<Vec<(usize, usize)>>()
+	dims.into_iter().unique().collect::<Vec<(u32, u32)>>()
 }
 
 // Commitment builder routine candidate
@@ -61,7 +61,7 @@ fn bench_par_build_commitments(c: &mut Criterion) {
 	let dims = generate_matrix_dimensions();
 
 	for dim in dims {
-		let dlen = dim.0 * dim.1 * (CHUNK - 2);
+		let dlen = (dim.0 * dim.1) as usize * (CHUNK - 2);
 
 		let mut seed = [0u8; 32];
 		let mut data = vec![0u8; dlen];
@@ -77,13 +77,13 @@ fn bench_par_build_commitments(c: &mut Criterion) {
 				"par_build_commitments/{}x{}/{} MB",
 				dim.0,
 				dim.1,
-				(dim.0 * dim.1 * CHUNK) >> 20
+				((dim.0 * dim.1) as usize * CHUNK) >> 20
 			),
 			|b| {
 				b.iter(|| {
 					let (_, _, _, _) = par_build_commitments(
-						black_box(dim.0),
-						black_box(dim.1),
+						black_box(BlockLenghtRows(dim.0)),
+						black_box(BlockLenghtColumns(dim.1)),
 						black_box(CHUNK),
 						black_box(&txs),
 						black_box(seed),
@@ -102,7 +102,7 @@ fn bench_build_proof(c: &mut Criterion) {
 	let mdims = generate_matrix_dimensions();
 
 	for dim in mdims {
-		let dlen = dim.0 * dim.1 * (CHUNK - 2);
+		let dlen = (dim.0 * dim.1) as usize * (CHUNK - 2);
 
 		let mut seed = [0u8; 32];
 		let mut data = vec![0u8; dlen];
@@ -113,23 +113,30 @@ fn bench_build_proof(c: &mut Criterion) {
 		let tx = AppExtrinsic::from(data.to_vec());
 		let txs = [tx];
 
-		let public_params = crate::testnet::public_params(dim.1);
+		let public_params = crate::testnet::public_params(BlockLenghtColumns(dim.1));
 
-		let (_, _, dims, mat) = par_build_commitments(dim.0, dim.1, CHUNK, &txs, seed).unwrap();
+		let (_, _, dims, mat) = par_build_commitments(
+			BlockLenghtRows(dim.0),
+			BlockLenghtColumns(dim.1),
+			CHUNK,
+			&txs,
+			seed,
+		)
+		.unwrap();
 
 		c.bench_function(
 			&format!(
 				"build_proof/{}x{}/ {} MB",
 				dim.0,
 				dim.1,
-				(dim.0 * dim.1 * CHUNK) >> 20
+				((dim.0 * dim.1) as usize * CHUNK) >> 20
 			),
 			|b| {
 				b.iter(|| {
-					let cell = Cell {
-						row: rng.next_u32() % dims.rows as u32,
-						col: rng.next_u32() % dims.cols as u32,
-					};
+					let cell = Cell::new(
+						BlockLenghtRows(rng.next_u32() % dims.rows.0),
+						BlockLenghtColumns(rng.next_u32() % dims.cols.0),
+					);
 
 					let proof = build_proof(&public_params, dims, &mat, &[cell]).unwrap();
 					assert_eq!(proof.len(), 80);
@@ -146,7 +153,7 @@ fn bench_verify_proof(c: &mut Criterion) {
 	let mdims = generate_matrix_dimensions();
 
 	for dim in mdims {
-		let dlen = dim.0 * dim.1 * (CHUNK - 2);
+		let dlen = (dim.0 * dim.1) as usize * (CHUNK - 2);
 
 		let mut seed = [0u8; 32];
 		let mut data = vec![0u8; dlen];
@@ -157,12 +164,19 @@ fn bench_verify_proof(c: &mut Criterion) {
 		let tx = AppExtrinsic::from(data.to_vec());
 		let txs = [tx];
 
-		let pp = crate::testnet::public_params(dim.1);
+		let pp = crate::testnet::public_params(BlockLenghtColumns(dim.1));
 
-		let (_, comms, dims, mat) = par_build_commitments(dim.0, dim.1, CHUNK, &txs, seed).unwrap();
+		let (_, comms, dims, mat) = par_build_commitments(
+			BlockLenghtRows(dim.0),
+			BlockLenghtColumns(dim.1),
+			CHUNK,
+			&txs,
+			seed,
+		)
+		.unwrap();
 
-		let row = rng.next_u32() % dims.rows as u32;
-		let col = rng.next_u32() % dims.cols as u32;
+		let row = BlockLenghtRows(rng.next_u32() % dims.rows.0);
+		let col = BlockLenghtColumns(rng.next_u32() % dims.cols.0);
 
 		let proof = build_proof(&pp, dims, &mat, &[Cell { row, col }]).unwrap();
 		assert_eq!(proof.len(), 80);
@@ -172,12 +186,19 @@ fn bench_verify_proof(c: &mut Criterion) {
 				"verify_proof/{}x{}/ {} MB",
 				dim.0,
 				dim.1,
-				(dim.0 * dim.1 * CHUNK) >> 20
+				((dim.0 * dim.1) as usize * CHUNK) >> 20
 			),
 			|b| {
 				b.iter(|| {
-					let comm = &comms[row as usize * 48..(row as usize + 1) * 48];
-					let flg = kc_verify_proof(col, &proof, comm, dims.rows, dims.cols, &pp);
+					let comm = &comms[row.as_usize() * 48..(row.as_usize() + 1) * 48];
+					let flg = kc_verify_proof(
+						col.0,
+						&proof,
+						comm,
+						dims.rows.as_usize(),
+						dims.cols.as_usize(),
+						&pp,
+					);
 
 					assert_eq!(flg.unwrap(), true);
 				});

--- a/kate/recovery/Cargo.toml
+++ b/kate/recovery/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "kate-recovery"
-version = "0.3.0"
+version = "0.4.0"
 authors = ["Denis Ermolin <denis.ermolin@matic.network>"]
 edition = "2018"
 

--- a/kate/recovery/Cargo.toml
+++ b/kate/recovery/Cargo.toml
@@ -11,6 +11,7 @@ dusk-plonk = { git = "https://github.com/maticnetwork/plonk.git", tag = "v0.12.0
 getrandom = { version = "0.2", features = ["js"] }
 serde = { version = "1.0", features = ["derive"] }
 thiserror = "1.0.37"
+derive_more = "0.99.17"
 
 [dev-dependencies]
 rand = "0.8.4"

--- a/kate/recovery/Cargo.toml
+++ b/kate/recovery/Cargo.toml
@@ -6,12 +6,12 @@ edition = "2018"
 
 [dependencies]
 codec = { package = "parity-scale-codec", version = "3.0.0", default-features = false, features = ["derive"] }
+derive_more = "0.99.17"
 dusk-bytes = "0.1.6"
 dusk-plonk = { git = "https://github.com/maticnetwork/plonk.git", tag = "v0.12.0-polygon-1" }
 getrandom = { version = "0.2", features = ["js"] }
 serde = { version = "1.0", features = ["derive"] }
 thiserror = "1.0.37"
-derive_more = "0.99.17"
 
 [dev-dependencies]
 rand = "0.8.4"

--- a/kate/recovery/src/com.rs
+++ b/kate/recovery/src/com.rs
@@ -147,7 +147,7 @@ fn reconstruct_available(
 				}
 				let cells = column_cells.values().cloned().collect::<Vec<_>>();
 				let row_count: u16 = dimensions
-					.rows
+					.extended_rows()
 					.try_into()
 					.map_err(|_| ReconstructionError::RowCountExceeded)?;
 

--- a/kate/recovery/src/index.rs
+++ b/kate/recovery/src/index.rs
@@ -22,7 +22,7 @@ impl AppDataIndex {
 	pub fn cells_ranges(&self) -> Vec<(u32, Range<u32>)> {
 		// Case if first app_id in index is zero is ignored
 		// since it should be asserted elsewhere
-		let prepend = self.index.get(0).map_or(vec![(0, 0)], |&(_, offset)| {
+		let prepend = self.index.first().map_or(vec![(0, 0)], |&(_, offset)| {
 			if offset == 0 {
 				vec![]
 			} else {

--- a/kate/recovery/src/matrix.rs
+++ b/kate/recovery/src/matrix.rs
@@ -50,7 +50,7 @@ pub struct Dimensions {
 impl Dimensions {
 	/// Creates new matrix dimensions.
 	/// Data layout is assumed to be row-wise.
-	pub fn new(rows: u16, cols: u16) -> Self { Dimensions { rows, cols } }
+	pub const fn new(rows: u16, cols: u16) -> Self { Dimensions { rows, cols } }
 
 	/// Matrix size.
 	pub fn size(&self) -> u32 { self.rows as u32 * self.cols as u32 }

--- a/kate/src/com.rs
+++ b/kate/src/com.rs
@@ -5,7 +5,11 @@ use std::{
 };
 
 use codec::Encode;
-use da_primitives::asdr::{AppExtrinsic, AppId};
+use da_primitives::{
+	asdr::{AppExtrinsic, AppId},
+	BlockLenghtColumns, BlockLenghtRows,
+};
+use derive_more::Constructor;
 use dusk_bytes::Serializable;
 use dusk_plonk::{
 	commitment_scheme::kzg10,
@@ -13,7 +17,7 @@ use dusk_plonk::{
 	fft::{EvaluationDomain, Evaluations},
 	prelude::BlsScalar,
 };
-use frame_support::ensure;
+use frame_support::{ensure, sp_runtime::SaturatedConversion};
 use log::info;
 use rand::{Rng, SeedableRng};
 use rand_chacha::ChaChaRng;
@@ -31,10 +35,12 @@ use crate::{
 	padded_len_of_pad_iec_9797_1, BlockDimensions, Seed, LOG_TARGET,
 };
 
-#[derive(Serialize, Deserialize)]
+#[derive(Serialize, Deserialize, Constructor, Clone, Copy)]
 pub struct Cell {
-	pub row: u32,
-	pub col: u32,
+	#[serde(flatten)]
+	pub row: BlockLenghtRows,
+	#[serde(flatten)]
+	pub col: BlockLenghtColumns,
 }
 
 #[derive(Debug)]
@@ -69,9 +75,9 @@ fn app_extrinsics_group_by_app_id(extrinsics: &[AppExtrinsic]) -> Vec<(AppId, Ve
 }
 
 pub fn flatten_and_pad_block(
-	max_rows_num: usize,
-	max_cols_num: usize,
-	chunk_size: usize,
+	max_rows: BlockLenghtRows,
+	max_cols: BlockLenghtColumns,
+	chunk_size: u32,
 	extrinsics: &[AppExtrinsic],
 	rng_seed: Seed,
 ) -> Result<(XtsLayout, FlatData, BlockDimensions), Error> {
@@ -102,18 +108,21 @@ pub fn flatten_and_pad_block(
 				.collect::<Vec<_>>()
 		})
 		.collect::<Vec<_>>();
+	let padded_block_len: u32 = padded_block
+		.len()
+		.try_into()
+		.map_err(|_| Error::BlockTooBig)?;
 
 	// Determine the block size after padding
-	let block_dims =
-		get_block_dimensions(padded_block.len(), max_rows_num, max_cols_num, chunk_size)?;
+	let block_dims = get_block_dimensions(padded_block_len, max_rows, max_cols, chunk_size)?;
 
 	ensure!(padded_block.len() <= block_dims.size(), Error::BlockTooBig);
 
 	let mut rng = ChaChaRng::from_seed(rng_seed);
 
-	assert!((block_dims.size() - padded_block.len()) % block_dims.chunk_size == 0);
+	assert!((block_dims.size() - padded_block.len()) % block_dims.chunk_size as usize == 0);
 
-	for _ in 0..((block_dims.size() - padded_block.len()) / block_dims.chunk_size) {
+	for _ in 0..((block_dims.size() - padded_block.len()) / block_dims.chunk_size as usize) {
 		let rnd_values: DataChunk = rng.gen();
 		padded_block.append(&mut pad_with_zeroes(rnd_values.to_vec(), chunk_size));
 	}
@@ -122,23 +131,18 @@ pub fn flatten_and_pad_block(
 }
 
 pub fn get_block_dimensions(
-	block_size: usize,
-	max_rows_num: usize,
-	max_cols_num: usize,
-	chunk_size: usize,
+	block_size: u32,
+	max_rows: BlockLenghtRows,
+	max_cols: BlockLenghtColumns,
+	chunk_size: u32,
 ) -> Result<BlockDimensions, Error> {
-	let max_block_dimensions = BlockDimensions {
-		rows: max_rows_num,
-		cols: max_cols_num,
-		chunk_size,
-	};
-
+	let max_block_dimensions = BlockDimensions::new(max_rows, max_cols, chunk_size);
 	ensure!(
-		block_size <= max_block_dimensions.size(),
+		block_size as usize <= max_block_dimensions.size(),
 		Error::BlockTooBig
 	);
 
-	if block_size == max_block_dimensions.size() || MAXIMUM_BLOCK_SIZE {
+	if block_size as usize == max_block_dimensions.size() || MAXIMUM_BLOCK_SIZE {
 		return Ok(max_block_dimensions);
 	}
 
@@ -149,14 +153,14 @@ pub fn get_block_dimensions(
 		nearest_power_2_size = MINIMUM_BLOCK_SIZE;
 	}
 
-	let total_cells = (nearest_power_2_size as f32 / chunk_size as f32).ceil() as usize;
+	let total_cells = (nearest_power_2_size as f32 / chunk_size as f32).ceil() as u32;
 
 	// we must minimize number of rows, to minimize header size
 	// (performance wise it doesn't matter)
-	let (cols, rows) = if total_cells > max_cols_num {
-		(max_cols_num, total_cells / max_cols_num)
+	let (cols, rows) = if total_cells > max_cols.0 {
+		(max_cols, BlockLenghtRows(total_cells / max_cols.0))
 	} else {
-		(total_cells, 1)
+		(total_cells.into(), 1.into())
 	};
 
 	Ok(BlockDimensions {
@@ -167,25 +171,25 @@ pub fn get_block_dimensions(
 }
 
 #[inline]
-fn pad_with_zeroes(mut chunk: Vec<u8>, length: usize) -> Vec<u8> {
-	chunk.resize(length, 0);
+fn pad_with_zeroes(mut chunk: Vec<u8>, length: u32) -> Vec<u8> {
+	chunk.resize(length as usize, 0);
 	chunk
 }
 
-fn pad_to_chunk(chunk: DataChunk, chunk_size: usize) -> Vec<u8> {
+fn pad_to_chunk(chunk: DataChunk, chunk_size: u32) -> Vec<u8> {
 	const_assert_eq!(DATA_CHUNK_SIZE, size_of::<DataChunk>());
 	debug_assert!(
-		chunk_size >= DATA_CHUNK_SIZE,
+		chunk_size as usize >= DATA_CHUNK_SIZE,
 		"`BlockLength.chunk_size` is valid by design .qed"
 	);
 
 	let mut padded = chunk.to_vec();
-	padded.resize(chunk_size, 0);
+	padded.resize(chunk_size as usize, 0);
 	padded
 }
 
 fn pad_iec_9797_1(mut data: Vec<u8>) -> Vec<DataChunk> {
-	let padded_size = padded_len_of_pad_iec_9797_1(data.len() as u32);
+	let padded_size = padded_len_of_pad_iec_9797_1(data.len().saturated_into());
 	// Add `PADDING_TAIL_VALUE` and fill with zeros.
 	data.push(PADDING_TAIL_VALUE);
 	data.resize(padded_size as usize, 0u8);
@@ -198,8 +202,13 @@ fn pad_iec_9797_1(mut data: Vec<u8>) -> Vec<DataChunk> {
 		.expect("Const assertion ensures this transformation to `DataChunk`. qed")
 }
 
-fn extend_column_with_zeros(column: &[BlsScalar], extended_rows_num: usize) -> Vec<BlsScalar> {
-	let mut result = column.to_vec();
+fn extend_column_with_zeros(
+	column: &[BlsScalar],
+	extended_rows: BlockLenghtRows,
+) -> Vec<BlsScalar> {
+	let extended_rows_num = extended_rows.as_usize();
+	let mut result = Vec::with_capacity(column.len() + extended_rows_num);
+	result.extend_from_slice(column);
 	result.resize(extended_rows_num, BlsScalar::zero());
 	result
 }
@@ -224,26 +233,25 @@ pub fn par_extend_data_matrix(
 	block: &[u8],
 ) -> Result<Vec<BlsScalar>, Error> {
 	let start = Instant::now();
-	let rows_num = block_dims.rows;
-	let extended_rows_num = rows_num * EXTENSION_FACTOR;
+	let extended_rows_num = block_dims.rows * EXTENSION_FACTOR;
 
-	let chunks = block.par_chunks_exact(block_dims.chunk_size);
+	let chunks = block.par_chunks_exact(block_dims.chunk_size as usize);
 	assert!(chunks.remainder().is_empty());
 
 	let mut chunk_elements = chunks
 		.into_par_iter()
 		.map(to_bls_scalar)
 		.collect::<Result<Vec<BlsScalar>, Error>>()?
-		.par_chunks_exact(rows_num)
+		.par_chunks_exact(block_dims.rows.0 as usize)
 		.flat_map(|column| extend_column_with_zeros(column, extended_rows_num))
 		.collect::<Vec<BlsScalar>>();
 
 	// extend data matrix, column by column
-	let extended_column_eval_domain = EvaluationDomain::new(extended_rows_num)?;
-	let column_eval_domain = EvaluationDomain::new(rows_num)?; // rows_num = column_length
+	let extended_column_eval_domain = EvaluationDomain::new(extended_rows_num.0 as usize)?;
+	let column_eval_domain = EvaluationDomain::new(block_dims.rows.0 as usize)?; // rows_num = column_length
 
 	chunk_elements
-		.par_chunks_exact_mut(extended_rows_num)
+		.par_chunks_exact_mut(extended_rows_num.0 as usize)
 		.for_each(|col| {
 			let half_len = col.len() / 2;
 			// (i)fft functions input parameter slice size has to be a power of 2, otherwise it panics
@@ -268,9 +276,8 @@ pub fn build_proof(
 	ext_data_matrix: &[BlsScalar],
 	cells: &[Cell],
 ) -> Result<Vec<u8>, Error> {
-	let rows_num = block_dims.rows;
-	let cols_num = block_dims.cols;
-	let extended_rows_num = rows_num * EXTENSION_FACTOR;
+	let cols_num = block_dims.cols.as_usize();
+	let extended_rows_num = (block_dims.rows * EXTENSION_FACTOR).as_usize();
 
 	const SPROOF_SIZE: usize = PROOF_SIZE + SCALAR_SIZE;
 
@@ -303,12 +310,12 @@ pub fn build_proof(
 		.into_par_iter()
 		.zip(result_bytes.par_chunks_exact_mut(SPROOF_SIZE))
 		.for_each(|(cell, res)| {
-			let r_index = cell.row as usize;
-			let c_index = cell.col as usize;
-
-			if (r_index >= extended_rows_num) || (c_index >= cols_num) {
+			let r_index = cell.row.as_usize();
+			if (r_index >= extended_rows_num) || (cell.col >= block_dims.cols) {
 				res.fill(0); // for bad cell identifier, fill whole proof with zero bytes !
 			} else {
+				let c_index = cell.col.as_usize();
+
 				// construct polynomial per extended matrix row
 				let row = (0..cols_num)
 					.into_par_iter()
@@ -328,7 +335,6 @@ pub fn build_proof(
 					},
 					Err(_) => {
 						res.fill(0); // for bad cell identifier, fill whole proof with zero bytes !
-						return;
 					},
 				};
 			}
@@ -346,9 +352,9 @@ pub fn build_proof(
 
 #[cfg(feature = "std")]
 pub fn par_build_commitments(
-	rows_num: usize,
-	cols_num: usize,
-	chunk_size: usize,
+	rows: BlockLenghtRows,
+	cols: BlockLenghtColumns,
+	chunk_size: u32,
 	extrinsics_by_key: &[AppExtrinsic],
 	rng_seed: Seed,
 ) -> Result<(XtsLayout, Vec<u8>, BlockDimensions, Vec<BlsScalar>), Error> {
@@ -356,7 +362,7 @@ pub fn par_build_commitments(
 
 	// generate data matrix first
 	let (tx_layout, block, block_dims) =
-		flatten_and_pad_block(rows_num, cols_num, chunk_size, extrinsics_by_key, rng_seed)?;
+		flatten_and_pad_block(rows, cols, chunk_size, extrinsics_by_key, rng_seed)?;
 
 	info!(
 		target: LOG_TARGET,
@@ -385,13 +391,16 @@ pub fn par_build_commitments(
 		);
 	}
 
-	let (prover_key, _) = public_params.trim(block_dims.cols).map_err(Error::from)?;
-	let row_eval_domain = EvaluationDomain::new(block_dims.cols).map_err(Error::from)?;
+	let (prover_key, _) = public_params
+		.trim(block_dims.cols.as_usize())
+		.map_err(Error::from)?;
+	let row_eval_domain = EvaluationDomain::new(block_dims.cols.as_usize()).map_err(Error::from)?;
 
 	let mut result_bytes: Vec<u8> = Vec::new();
-	result_bytes.reserve_exact(PROVER_KEY_SIZE * extended_rows_num);
+	let result_bytes_len = (PROVER_KEY_SIZE * extended_rows_num).as_usize();
+	result_bytes.reserve_exact(result_bytes_len);
 	unsafe {
-		result_bytes.set_len(PROVER_KEY_SIZE * extended_rows_num);
+		result_bytes.set_len(result_bytes_len);
 	}
 
 	info!(
@@ -402,18 +411,20 @@ pub fn par_build_commitments(
 
 	let start = Instant::now();
 
-	(0..extended_rows_num)
+	(0..extended_rows_num.as_usize())
 		.into_par_iter()
 		.map(|i| {
-			let mut row = Vec::with_capacity(block_dims.cols);
+			let mut row = Vec::with_capacity(block_dims.cols.as_usize());
 
-			for j in 0..block_dims.cols {
-				row.push(ext_data_matrix[i + j * extended_rows_num]);
-			}
+			(0..block_dims.cols.as_usize() * extended_rows_num.as_usize())
+				.step_by(extended_rows_num.as_usize())
+				.for_each(|j| {
+					row.push(ext_data_matrix[i + j]);
+				});
 
 			Evaluations::from_vec_and_domain(row, row_eval_domain).interpolate()
 		})
-		.zip(result_bytes.par_chunks_exact_mut(PROVER_KEY_SIZE))
+		.zip(result_bytes.par_chunks_exact_mut(PROVER_KEY_SIZE.as_usize()))
 		.map(|(poly, res)| {
 			prover_key
 				.commit(&poly)
@@ -423,7 +434,7 @@ pub fn par_build_commitments(
 		})
 		.collect::<Result<Vec<(_, _)>, _>>()?
 		.into_par_iter()
-		.for_each(|(key_bytes, res)| res.copy_from_slice(&key_bytes[..PROVER_KEY_SIZE]));
+		.for_each(|(key_bytes, res)| res.copy_from_slice(&key_bytes[..PROVER_KEY_SIZE.as_usize()]));
 
 	info!(
 		target: "system",
@@ -461,16 +472,20 @@ mod tests {
 		padded_len,
 	};
 
-	#[test_case(0,   256, 256 => BlockDimensions { rows: 1, cols: 4  , chunk_size: 32} ; "block size zero")]
-	#[test_case(11,   256, 256 => BlockDimensions { rows: 1, cols: 4  , chunk_size: 32} ; "below minimum block size")]
-	#[test_case(300,  256, 256 => BlockDimensions { rows: 1, cols: 16 , chunk_size: 32} ; "regular case")]
-	#[test_case(513,  256, 256 => BlockDimensions { rows: 1, cols: 32 , chunk_size: 32} ; "minimum overhead after 512")]
-	#[test_case(8192, 256, 256 => BlockDimensions { rows: 1, cols: 256, chunk_size: 32} ; "maximum cols")]
-	#[test_case(8224, 256, 256 => BlockDimensions { rows: 2, cols: 256, chunk_size: 32} ; "two rows")]
-	#[test_case(2097152, 256, 256 => BlockDimensions { rows: 256, cols: 256, chunk_size: 32} ; "max block size")]
+	#[test_case(0,   256, 256 => BlockDimensions::new(1, 4, 32) ; "block size zero")]
+	#[test_case(11,   256, 256 => BlockDimensions::new(1, 4, 32) ; "below minimum block size")]
+	#[test_case(300,  256, 256 => BlockDimensions::new(1, 16, 32) ; "regular case")]
+	#[test_case(513,  256, 256 => BlockDimensions::new(1, 32, 32) ; "minimum overhead after 512")]
+	#[test_case(8192, 256, 256 => BlockDimensions::new(1, 256, 32) ; "maximum cols")]
+	#[test_case(8224, 256, 256 => BlockDimensions::new(2, 256, 32) ; "two rows")]
+	#[test_case(2097152, 256, 256 => BlockDimensions::new(256, 256, 32) ; "max block size")]
 	#[test_case(2097155, 256, 256 => panics "BlockTooBig" ; "too much data")]
-	fn test_get_block_dimensions(size: usize, rows: usize, cols: usize) -> BlockDimensions {
-		get_block_dimensions(size, rows, cols, 32).unwrap()
+	fn test_get_block_dimensions<R, C>(size: u32, rows: R, cols: C) -> BlockDimensions
+	where
+		R: Into<BlockLenghtRows>,
+		C: Into<BlockLenghtColumns>,
+	{
+		get_block_dimensions(size, rows.into(), cols.into(), 32).unwrap()
 	}
 
 	#[test]
@@ -504,11 +519,7 @@ mod tests {
 		})
 		.collect::<Vec<_>>();
 
-		let block_dims = BlockDimensions {
-			rows: 2,
-			cols: 4,
-			chunk_size: 32,
-		};
+		let block_dims = BlockDimensions::new(BlockLenghtRows(2), BlockLenghtColumns(4), 32);
 		let block = (0..=247)
 			.collect::<Vec<u8>>()
 			.chunks_exact(DATA_CHUNK_SIZE)
@@ -558,14 +569,15 @@ mod tests {
 			},
 		];
 
-		let expected_dims = BlockDimensions {
-			rows: 1,
-			cols: 16,
+		let expected_dims = BlockDimensions::new(1, 16, chunk_size);
+		let (layout, data, dims) = flatten_and_pad_block(
+			128.into(),
+			256.into(),
 			chunk_size,
-		};
-		let (layout, data, dims) =
-			flatten_and_pad_block(128, 256, chunk_size, extrinsics.as_slice(), Seed::default())
-				.unwrap();
+			extrinsics.as_slice(),
+			Seed::default(),
+		)
+		.unwrap();
 
 		let expected_layout = vec![(0.into(), 2), (1.into(), 2), (2.into(), 2), (3.into(), 3)];
 		assert_eq!(layout, expected_layout, "The layouts don't match");
@@ -609,7 +621,7 @@ mod tests {
 
 		const RNG_SEED: Seed = [42u8; 32];
 		matrix
-			.chunks_exact(dimensions.rows * 2)
+			.chunks_exact(dimensions.rows.as_usize() * 2)
 			.enumerate()
 			.map(|(col, e)| (col as u16, e))
 			.flat_map(|(col, e)| {
@@ -646,17 +658,22 @@ mod tests {
 		})
 	}
 
-	fn random_cells(cols: usize, rows: usize, percents: usize) -> Vec<Cell> {
+	fn random_cells(
+		max_cols: BlockLenghtColumns,
+		max_rows: BlockLenghtRows,
+		percents: usize,
+	) -> Vec<Cell> {
 		assert!(percents > 0 && percents <= 100);
+		let max_cols = max_cols.into();
+		let max_rows = max_rows.into();
 
 		let rng = &mut ChaChaRng::from_seed([0u8; 32]);
-		let amount = (cols as f32 * rows as f32 * (percents as f32 / 100.0)).ceil() as usize;
+		let amount = ((max_cols * max_rows) as f32 * (percents as f32 / 100.0)).ceil() as usize;
 
-		(0..cols)
-			.flat_map(move |col| (0..rows).map(move |row| (row, col)))
-			.map(|(row, col)| Cell {
-				col: col as u32,
-				row: row as u32,
+		(0..max_cols)
+			.flat_map(move |col| {
+				(0..max_rows)
+					.map(move |row| Cell::new(BlockLenghtRows(row), BlockLenghtColumns(col)))
 			})
 			.choose_multiple(rng, amount)
 	}
@@ -665,10 +682,11 @@ mod tests {
 	#![proptest_config(ProptestConfig::with_cases(20))]
 	#[test]
 	fn test_build_and_reconstruct(ref xts in app_extrinsics_strategy())  {
-		let (layout, commitments, dims, matrix) = par_build_commitments(64, 16, 32, xts, Seed::default()).unwrap();
+		let (layout, commitments, dims, matrix) = par_build_commitments(
+			BlockLenghtRows(64), BlockLenghtColumns(16), 32, xts, Seed::default()).unwrap();
 
 		let columns = sample_cells_from_matrix(&matrix, &dims, None);
-		let extended_dims = ExtendedMatrixDimensions{cols: dims.cols, rows: dims.rows * 2};
+		let extended_dims = ExtendedMatrixDimensions{cols: dims.cols.0, rows: dims.rows.0 * 2};
 		let index = AppDataIndex::try_from(layout.as_slice()).unwrap();
 		let reconstructed = reconstruct_extrinsics(&index, &extended_dims, columns).unwrap();
 		for (result, xt) in reconstructed.iter().zip(xts) {
@@ -676,17 +694,17 @@ mod tests {
 		prop_assert_eq!(result.1[0].as_slice(), &xt.data);
 		}
 
-		let public_params = crate::testnet::public_params(MAX_BLOCK_COLUMNS as usize);
+		let public_params = crate::testnet::public_params(MAX_BLOCK_COLUMNS);
 		let pp = testnet::public_params(dims.cols);
 		for cell in random_cells(dims.cols, dims.rows, 1) {
-			let col = cell.col;
-			let row = cell.row as usize;
+			let col = cell.col.into();
+			let row = cell.row.as_usize();
 
 			let proof = build_proof(&public_params, dims, &matrix, &[cell]).unwrap();
 			prop_assert!(proof.len() == 80);
 
 			let commitment = &commitments[row * 48..(row + 1) * 48];
-			let verification =  kate_proof::kc_verify_proof(col, &proof, commitment, dims.rows as usize, dims.cols as usize, &pp);
+			let verification =  kate_proof::kc_verify_proof(col, &proof, commitment, dims.rows.as_usize(), dims.cols.as_usize(), &pp);
 			prop_assert!(verification.is_ok());
 		}
 	}
@@ -695,8 +713,8 @@ mod tests {
 	#[test]
 	// Test build_commitments() function with a predefined input
 	fn test_build_commitments_simple_commitment_check() {
-		let block_rows = 256;
-		let block_cols = 256;
+		let block_rows = BlockLenghtRows(256);
+		let block_cols = BlockLenghtColumns(256);
 		let chunk_size = 32;
 		let original_data = br#"test"#;
 		let hash: Seed = [
@@ -714,8 +732,8 @@ mod tests {
 		.unwrap();
 
 		assert_eq!(dimensions, BlockDimensions {
-			rows: 1,
-			cols: 4,
+			rows: 1.into(),
+			cols: 4.into(),
 			chunk_size: 32
 		});
 		let expected_commitments = hex!("960F08F97D3A8BD21C3F5682366130132E18E375A587A1E5900937D7AA5F33C4E20A1C0ACAE664DCE1FD99EDC2693B8D960F08F97D3A8BD21C3F5682366130132E18E375A587A1E5900937D7AA5F33C4E20A1C0ACAE664DCE1FD99EDC2693B8D");
@@ -747,14 +765,21 @@ get erasure coded to ensure redundancy."#;
 
 		let chunk_size = 32;
 
-		let (layout, data, dims) = flatten_and_pad_block(32, 4, chunk_size, &xts, hash).unwrap();
+		let (layout, data, dims) = flatten_and_pad_block(
+			BlockLenghtRows(32),
+			BlockLenghtColumns(4),
+			chunk_size,
+			&xts,
+			hash,
+		)
+		.unwrap();
 		let coded: Vec<BlsScalar> = par_extend_data_matrix(dims, &data[..]).unwrap();
 
 		let cols_1 = sample_cells_from_matrix(&coded, &dims, Some(&[0, 1]));
 
 		let extended_dims = ExtendedMatrixDimensions {
-			cols: dims.cols,
-			rows: dims.rows * 2,
+			cols: dims.cols.0,
+			rows: dims.rows.0 * 2,
 		};
 
 		let index = AppDataIndex::try_from(layout.as_slice()).unwrap();
@@ -787,14 +812,23 @@ get erasure coded to ensure redundancy."#;
 
 		let chunk_size = 32;
 
-		let (layout, data, dims) = flatten_and_pad_block(32, 4, chunk_size, &xts, hash).unwrap();
+		let (layout, data, dims) = flatten_and_pad_block(
+			BlockLenghtRows(32),
+			BlockLenghtColumns(4),
+			chunk_size,
+			&xts,
+			hash,
+		)
+		.unwrap();
 		let coded = par_extend_data_matrix(dims, &data[..]).unwrap();
 
 		let extended_dims = ExtendedMatrixDimensions {
-			cols: dims.cols,
-			rows: dims.rows * 2,
+			cols: dims.cols.0,
+			rows: dims.rows.0 * 2,
 		};
-		let extended_matrix = coded.chunks(extended_dims.rows).collect::<Vec<_>>();
+		let extended_matrix = coded
+			.chunks(extended_dims.rows as usize)
+			.collect::<Vec<_>>();
 
 		let index = AppDataIndex::try_from(layout.as_slice()).unwrap();
 		for xt in xts {
@@ -827,8 +861,8 @@ Let's see how this gets encoded and then reconstructed by sampling only some dat
 		let hash = Seed::default();
 		let chunk_size = 32;
 		let (layout, data, dims) = flatten_and_pad_block(
-			128,
-			2,
+			BlockLenghtRows(128),
+			BlockLenghtColumns(2),
 			chunk_size,
 			&[AppExtrinsic::from(orig_data.to_vec())],
 			hash,
@@ -840,8 +874,8 @@ Let's see how this gets encoded and then reconstructed by sampling only some dat
 		let cols = sample_cells_from_matrix(&coded, &dims, None);
 
 		let extended_dims = ExtendedMatrixDimensions {
-			cols: dims.cols,
-			rows: dims.rows * 2,
+			cols: dims.cols.0,
+			rows: dims.rows.0 * 2,
 		};
 		let index = AppDataIndex::try_from(layout.as_slice()).unwrap();
 		let res = reconstruct_extrinsics(&index, &extended_dims, cols).unwrap();
@@ -869,14 +903,21 @@ Let's see how this gets encoded and then reconstructed by sampling only some dat
 		// The hash is used for seed for padding the block to next power of two value
 		let hash = Seed::default();
 		let chunk_size = 32;
-		let (layout, data, dims) = flatten_and_pad_block(128, 2, chunk_size, &xts, hash).unwrap();
+		let (layout, data, dims) = flatten_and_pad_block(
+			BlockLenghtRows(128),
+			BlockLenghtColumns(2),
+			chunk_size,
+			&xts,
+			hash,
+		)
+		.unwrap();
 
 		let coded: Vec<BlsScalar> = par_extend_data_matrix(dims, &data[..]).unwrap();
 
 		let cols = sample_cells_from_matrix(&coded, &dims, None);
 		let extended_dims = ExtendedMatrixDimensions {
-			cols: dims.cols,
-			rows: dims.rows * 2,
+			cols: dims.cols.0,
+			rows: dims.rows.0 * 2,
 		};
 
 		let index = AppDataIndex::try_from(layout.as_slice()).unwrap();
@@ -937,12 +978,13 @@ Let's see how this gets encoded and then reconstructed by sampling only some dat
 	#[test_case( build_extrinsics(&[5,64,120]), 32 => padded_len_group(&[5,64,120], 32) ; "Extra chunk 2 per ext")]
 	#[test_case( build_extrinsics(&[]), 32 => padded_len_group(&[], 32) ; "Empty chunk list")]
 	#[test_case( build_extrinsics(&[4096]), 32 => padded_len_group(&[4096], 32) ; "4K chunk")]
-	fn test_padding_len(extrinsics: Vec<Vec<u8>>, chunk_size: usize) -> u32 {
+	fn test_padding_len(extrinsics: Vec<Vec<u8>>, chunk_size: u32) -> u32 {
 		extrinsics
 			.into_iter()
 			.flat_map(pad_iec_9797_1)
-			.map(|chunk| pad_to_chunk(chunk, chunk_size).len() as u32)
-			.sum()
+			.map(|chunk| pad_to_chunk(chunk, chunk_size).len())
+			.sum::<usize>()
+			.saturated_into()
 	}
 
 	#[test]
@@ -959,7 +1001,7 @@ Let's see how this gets encoded and then reconstructed by sampling only some dat
 				data: data.clone(),
 			})
 			.collect::<Vec<_>>();
-		par_build_commitments(4, 4, 32, &xts, hash).unwrap();
+		par_build_commitments(BlockLenghtRows(4), BlockLenghtColumns(4), 32, &xts, hash).unwrap();
 	}
 
 	#[test]
@@ -971,6 +1013,6 @@ Let's see how this gets encoded and then reconstructed by sampling only some dat
 			app_id: AppId(0),
 			data: vec![0; 31 * 8],
 		}];
-		par_build_commitments(4, 4, 32, &xts, hash).unwrap();
+		par_build_commitments(BlockLenghtRows(4), BlockLenghtColumns(4), 32, &xts, hash).unwrap();
 	}
 }

--- a/kate/src/com.rs
+++ b/kate/src/com.rs
@@ -37,11 +37,9 @@ use crate::{
 	padded_len_of_pad_iec_9797_1, BlockDimensions, Seed, LOG_TARGET,
 };
 
-#[derive(Serialize, Deserialize, Constructor, Clone, Copy)]
+#[derive(Serialize, Deserialize, Constructor, Clone, Copy, PartialEq, Debug)]
 pub struct Cell {
-	#[serde(flatten)]
 	pub row: BlockLengthRows,
-	#[serde(flatten)]
 	pub col: BlockLengthColumns,
 }
 
@@ -1124,4 +1122,8 @@ Let's see how this gets encoded and then reconstructed by sampling only some dat
 		}];
 		par_build_commitments(BlockLengthRows(4), BlockLengthColumns(4), 32, &xts, hash).unwrap();
 	}
+
+	#[test_case( r#"{ "row": 42, "col": 99 }"# => Cell::new(42.into(),99.into()) ; "Simple" )]
+	#[test_case( r#"{ "row": 4294967295, "col": 99 }"# => Cell::new(4_294_967_295.into(),99.into()) ; "Max row" )]
+	fn serde_block_length_types_untagged(data: &str) -> Cell { serde_json::from_str(data).unwrap() }
 }

--- a/kate/src/com.rs
+++ b/kate/src/com.rs
@@ -248,15 +248,13 @@ pub fn to_bls_scalar(chunk: &[u8]) -> Result<BlsScalar, Error> {
 /// This means that extension factor has to be multiple of 2,
 /// and that original data will be interleaved with erasure codes,
 /// instead of being in first k chunks of a column.
-#[cfg(feature = "alloc")]
+#[cfg(feature = "std")]
 pub fn par_extend_data_matrix(
 	block_dims: BlockDimensions,
 	block: &[u8],
 ) -> Result<Vec<BlsScalar>, Error> {
-	use kate_recovery::matrix::Dimensions;
-
 	let start = Instant::now();
-	let dimensions: Dimensions = block_dims.try_into().map_err(|_| Error::BlockTooBig)?;
+	let dimensions: matrix::Dimensions = block_dims.try_into().map_err(|_| Error::BlockTooBig)?;
 	let rows_num: usize = dimensions.rows.into();
 	let extended_rows_num = BlockLengthRows(dimensions.extended_rows());
 	let chunks = block.par_chunks_exact(block_dims.chunk_size as usize);

--- a/kate/src/lib.rs
+++ b/kate/src/lib.rs
@@ -1,11 +1,10 @@
 #![cfg_attr(not(feature = "std"), no_std)]
 
-use std::convert::TryInto;
-
 use da_primitives::{BlockLengthColumns, BlockLengthRows};
 #[cfg(feature = "std")]
 pub use dusk_plonk::{commitment_scheme::kzg10::PublicParameters, prelude::BlsScalar};
 use frame_support::sp_runtime::SaturatedConversion;
+#[cfg(feature = "std")]
 use kate_recovery::matrix::Dimensions;
 use static_assertions::const_assert_ne;
 
@@ -102,8 +101,9 @@ impl BlockDimensions {
 	}
 }
 
-impl TryInto<Dimensions> for BlockDimensions {
-	type Error = std::num::TryFromIntError;
+#[cfg(feature = "std")]
+impl sp_std::convert::TryInto<Dimensions> for BlockDimensions {
+	type Error = sp_std::num::TryFromIntError;
 
 	fn try_into(self) -> Result<Dimensions, Self::Error> {
 		let rows = self.rows.0.try_into()?;

--- a/kate/src/lib.rs
+++ b/kate/src/lib.rs
@@ -20,8 +20,8 @@ pub mod config {
 	pub const SCALAR_SIZE_WIDE: usize = 64;
 	pub const SCALAR_SIZE: usize = 32;
 	pub const DATA_CHUNK_SIZE: usize = 31; // Actual chunk size is 32 after 0 padding is done
-	pub const EXTENSION_FACTOR: BlockLengthRows = BlockLengthRows(2);
-	pub const PROVER_KEY_SIZE: BlockLengthRows = BlockLengthRows(48);
+	pub const EXTENSION_FACTOR: u32 = 2;
+	pub const PROVER_KEY_SIZE: u32 = 48;
 	pub const PROOF_SIZE: usize = 48;
 	// MINIMUM_BLOCK_SIZE, MAX_BLOCK_ROWS and MAX_BLOCK_COLUMNS have to be a power of 2 because of the FFT functions requirements
 	pub const MINIMUM_BLOCK_SIZE: usize = 128;

--- a/kate/src/lib.rs
+++ b/kate/src/lib.rs
@@ -1,6 +1,6 @@
 #![cfg_attr(not(feature = "std"), no_std)]
 
-use da_primitives::{BlockLenghtColumns, BlockLenghtRows};
+use da_primitives::{BlockLengthColumns, BlockLengthRows};
 #[cfg(feature = "std")]
 pub use dusk_plonk::{commitment_scheme::kzg10::PublicParameters, prelude::BlsScalar};
 use frame_support::sp_runtime::SaturatedConversion;
@@ -12,25 +12,25 @@ pub const LOG_TARGET: &str = "kate";
 pub type Seed = [u8; 32];
 
 pub mod config {
-	use super::{BlockLenghtColumns, BlockLenghtRows};
+	use super::{BlockLengthColumns, BlockLengthRows};
 
 	pub const SCALAR_SIZE_WIDE: usize = 64;
 	pub const SCALAR_SIZE: usize = 32;
 	pub const DATA_CHUNK_SIZE: usize = 31; // Actual chunk size is 32 after 0 padding is done
-	pub const EXTENSION_FACTOR: BlockLenghtRows = BlockLenghtRows(2);
-	pub const PROVER_KEY_SIZE: BlockLenghtRows = BlockLenghtRows(48);
+	pub const EXTENSION_FACTOR: BlockLengthRows = BlockLengthRows(2);
+	pub const PROVER_KEY_SIZE: BlockLengthRows = BlockLengthRows(48);
 	pub const PROOF_SIZE: usize = 48;
 	// MINIMUM_BLOCK_SIZE, MAX_BLOCK_ROWS and MAX_BLOCK_COLUMNS have to be a power of 2 because of the FFT functions requirements
 	pub const MINIMUM_BLOCK_SIZE: usize = 128;
-	pub const MAX_BLOCK_ROWS: BlockLenghtRows = if cfg!(feature = "extended-columns") {
-		BlockLenghtRows(128)
+	pub const MAX_BLOCK_ROWS: BlockLengthRows = if cfg!(feature = "extended-columns") {
+		BlockLengthRows(128)
 	} else {
-		BlockLenghtRows(256)
+		BlockLengthRows(256)
 	};
-	pub const MAX_BLOCK_COLUMNS: BlockLenghtColumns = if cfg!(feature = "extended-columns") {
-		BlockLenghtColumns(512)
+	pub const MAX_BLOCK_COLUMNS: BlockLengthColumns = if cfg!(feature = "extended-columns") {
+		BlockLengthColumns(512)
 	} else {
-		BlockLenghtColumns(256)
+		BlockLengthColumns(256)
 	};
 	pub const MAXIMUM_BLOCK_SIZE: bool = cfg!(feature = "maximum-block-size");
 }
@@ -73,8 +73,8 @@ pub fn padded_len(len: u32, chunk_size: u32) -> u32 {
 
 #[derive(Clone, Copy, PartialEq, Eq, Debug)]
 pub struct BlockDimensions {
-	pub rows: BlockLenghtRows,
-	pub cols: BlockLenghtColumns,
+	pub rows: BlockLengthRows,
+	pub cols: BlockLengthColumns,
 	pub chunk_size: u32,
 }
 
@@ -88,8 +88,8 @@ impl BlockDimensions {
 
 	pub fn new<R, C>(rows: R, cols: C, chunk_size: u32) -> Self
 	where
-		R: Into<BlockLenghtRows>,
-		C: Into<BlockLenghtColumns>,
+		R: Into<BlockLengthRows>,
+		C: Into<BlockLengthColumns>,
 	{
 		Self {
 			rows: rows.into(),
@@ -103,7 +103,7 @@ impl BlockDimensions {
 pub mod testnet {
 	use std::{collections::HashMap, sync::Mutex};
 
-	use da_primitives::BlockLenghtColumns;
+	use da_primitives::BlockLengthColumns;
 	use dusk_plonk::commitment_scheme::kzg10::PublicParameters;
 	use once_cell::sync::Lazy;
 	use rand::SeedableRng;
@@ -112,7 +112,7 @@ pub mod testnet {
 	static SRS_DATA: Lazy<Mutex<HashMap<usize, PublicParameters>>> =
 		Lazy::new(|| Mutex::new(HashMap::new()));
 
-	pub fn public_params(max_degree: BlockLenghtColumns) -> PublicParameters {
+	pub fn public_params(max_degree: BlockLengthColumns) -> PublicParameters {
 		let max_degree = max_degree.as_usize();
 		let mut srs_data_locked = SRS_DATA.lock().unwrap();
 		srs_data_locked

--- a/primitives/avail/Cargo.toml
+++ b/primitives/avail/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "da-primitives"
-version = "0.2.2"
+version = "0.2.3"
 authors = []
 edition = "2018"
 

--- a/primitives/avail/Cargo.toml
+++ b/primitives/avail/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "da-primitives"
-version = "0.2.3"
+version = "0.4.0"
 authors = []
 edition = "2018"
 

--- a/primitives/avail/src/data_proof.rs
+++ b/primitives/avail/src/data_proof.rs
@@ -83,7 +83,7 @@ where
 			.map(|(idx, proof)| {
 				<[u8; 32]>::try_from(proof.as_ref())
 					.map_err(|_| InvalidProof(idx))
-					.map(|raw| H256(raw))
+					.map(H256::from)
 			})
 			.collect::<Result<Vec<H256>, _>>()?;
 		let number_of_leaves =

--- a/primitives/avail/src/lib.rs
+++ b/primitives/avail/src/lib.rs
@@ -100,9 +100,9 @@ where
 	Constructor,
 )]
 #[mul(forward)]
-pub struct BlockLenghtColumns(#[codec(compact)] pub u32);
+pub struct BlockLengthColumns(#[codec(compact)] pub u32);
 
-impl BlockLenghtColumns {
+impl BlockLengthColumns {
 	#[inline]
 	pub fn as_usize(&self) -> usize { self.0 as usize }
 }
@@ -128,9 +128,9 @@ impl BlockLenghtColumns {
 	Constructor,
 )]
 #[mul(forward)]
-pub struct BlockLenghtRows(#[codec(compact)] pub u32);
+pub struct BlockLengthRows(#[codec(compact)] pub u32);
 
-impl BlockLenghtRows {
+impl BlockLengthRows {
 	#[inline]
 	pub fn as_usize(&self) -> usize { self.0 as usize }
 }

--- a/primitives/avail/src/lib.rs
+++ b/primitives/avail/src/lib.rs
@@ -56,6 +56,8 @@ pub enum InvalidTransactionCustomId {
 	InvalidAppId = 137,
 	/// Extrinsic is not allowed for the given `AppId`.
 	ForbiddenAppId,
+	/// Max padded length was exceeded.
+	MaxPaddedLenExceeded,
 }
 
 /// Provides an implementation of [`frame_support::traits::Randomness`] that should only be used in

--- a/primitives/avail/src/lib.rs
+++ b/primitives/avail/src/lib.rs
@@ -1,5 +1,10 @@
 #![cfg_attr(not(feature = "std"), no_std)]
 
+use codec::{Decode, Encode};
+use derive_more::{Add, Constructor, Display, From, Into, Mul};
+use scale_info::TypeInfo;
+#[cfg(feature = "std")]
+use serde::{Deserialize, Serialize};
 use sp_runtime::Perbill;
 
 /// Customized headers.
@@ -70,4 +75,60 @@ where
 			T::default(),
 		)
 	}
+}
+
+/// Strong type for `BlockLength::cols`
+#[cfg_attr(feature = "std", derive(Serialize, Deserialize))]
+#[derive(
+	Clone,
+	Copy,
+	Debug,
+	From,
+	Into,
+	Add,
+	Mul,
+	Display,
+	PartialEq,
+	Eq,
+	Encode,
+	Decode,
+	TypeInfo,
+	PartialOrd,
+	Ord,
+	Constructor,
+)]
+#[mul(forward)]
+pub struct BlockLenghtColumns(#[codec(compact)] pub u32);
+
+impl BlockLenghtColumns {
+	#[inline]
+	pub fn as_usize(&self) -> usize { self.0 as usize }
+}
+
+/// Strong type for `BlockLength::rows`
+#[cfg_attr(feature = "std", derive(Serialize, Deserialize))]
+#[derive(
+	Clone,
+	Copy,
+	Debug,
+	From,
+	Into,
+	Add,
+	Mul,
+	Display,
+	PartialEq,
+	Eq,
+	Encode,
+	Decode,
+	TypeInfo,
+	PartialOrd,
+	Ord,
+	Constructor,
+)]
+#[mul(forward)]
+pub struct BlockLenghtRows(#[codec(compact)] pub u32);
+
+impl BlockLenghtRows {
+	#[inline]
+	pub fn as_usize(&self) -> usize { self.0 as usize }
 }

--- a/primitives/nomad/merkle/src/light.rs
+++ b/primitives/nomad/merkle/src/light.rs
@@ -18,6 +18,7 @@ impl<const N: usize> AssertLightMerkleN<N> {
 /// Verify at compilation time that `N <= TREE_DEPTH`
 #[inline]
 #[allow(path_statements)]
+#[allow(clippy::no_effect)]
 const fn const_assert_n_is_valid<const N: usize>() {
 	AssertLightMerkleN::<N>::N_LESS_EQ_TREE_DEPTH;
 }

--- a/primitives/nomad/nomad-core/src/typed_message.rs
+++ b/primitives/nomad/nomad-core/src/typed_message.rs
@@ -21,6 +21,8 @@ where
 	/// Size of encoded struct (+ 1 for u8 type tag)
 	fn len(&self) -> usize { mem::size_of::<Self>() + 1 }
 
+	fn is_empty(&self) -> bool { self.len() == 0 }
+
 	/// Encode self into `BoundedVec<u8, S>`
 	fn encode(&self) -> Vec<u8>;
 }


### PR DESCRIPTION
# Description
- Rows use the strong type `BlockLenghtRows` and Columns use `BlockLenghtColumns`, so it is harder to mess both of them.
- Remove castings from `u32` to `usize`.
- Use `try_into()` on conversions from `usize` to `u32`.
- Replace `usize` by `u32`.
- Use safe `checked_*` operations for `rows` and `cols`, and `try_into` to cast to `u16`.
- Use `saturating_*` operations on infallible methods. 