### PR TITLE
Format source

### DIFF
--- a/.github/workflows/default.yml
+++ b/.github/workflows/default.yml
@@ -28,16 +28,6 @@ jobs:
             target/
           key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
 
-      - name: Install nightly `rust-fmt` 
-        uses: actions-rs/toolchain@v1
-        with:
-            # NOTE: Until https://github.com/actions-rs/toolchain/pull/209 is merged,
-            # this should be synced with rust-toolchain.toml file.
-            # After merge, this section should be removed.
-            toolchain: nightly-2021-12-05
-            components: rustfmt
-            profile: minimal
-
       - name: Install Rust toolchain 1.64 
         uses: actions-rs/toolchain@v1
         with:
@@ -48,6 +38,12 @@ jobs:
 
       - name: Check `TOML`, `JSON`, and `MarkDown` formatting
         uses: dprint/check@v2.1
+
+      - name: Check code formatting
+        uses: actions-rs/cargo@v1
+        with:
+          command: fmt
+          args: --check
 
       - name: Run tests
         uses: actions-rs/cargo@v1

--- a/.rustfmt.toml
+++ b/.rustfmt.toml
@@ -1,10 +1,10 @@
-fn_single_line = true
-match_arm_blocks = true
+# fn_single_line = true
+# match_arm_blocks = true
 match_block_trailing_comma = true
-imports_granularity = "Crate"
-overflow_delimited_expr = true
-reorder_impl_items = true
-group_imports = "StdExternalCrate"
+# imports_granularity = "Crate"
+# overflow_delimited_expr = true
+# reorder_impl_items = true
+# group_imports = "StdExternalCrate"
 use_field_init_shorthand = true
 edition = "2018"
 hard_tabs = true

--- a/kate/recovery/src/commitments.rs
+++ b/kate/recovery/src/commitments.rs
@@ -36,7 +36,9 @@ pub enum Error {
 }
 
 impl From<TryFromSliceError> for Error {
-	fn from(e: TryFromSliceError) -> Self { Self::InvalidData(DataError::SliceError(e)) }
+	fn from(e: TryFromSliceError) -> Self {
+		Self::InvalidData(DataError::SliceError(e))
+	}
 }
 
 impl From<dusk_bytes::Error> for Error {
@@ -50,7 +52,9 @@ impl From<dusk_bytes::Error> for Error {
 }
 
 impl From<dusk_plonk::error::Error> for Error {
-	fn from(e: dusk_plonk::error::Error) -> Self { Self::InvalidData(DataError::PlonkError(e)) }
+	fn from(e: dusk_plonk::error::Error) -> Self {
+		Self::InvalidData(DataError::PlonkError(e))
+	}
 }
 
 fn try_into_scalar(chunk: &[u8]) -> Result<BlsScalar, Error> {

--- a/kate/recovery/src/data.rs
+++ b/kate/recovery/src/data.rs
@@ -21,11 +21,17 @@ pub struct Cell {
 }
 
 impl Cell {
-	pub fn reference(&self, block: u32) -> String { self.position.reference(block) }
+	pub fn reference(&self, block: u32) -> String {
+		self.position.reference(block)
+	}
 
-	pub fn data(&self) -> [u8; 32] { self.content[48..].try_into().expect("content is 80 bytes") }
+	pub fn data(&self) -> [u8; 32] {
+		self.content[48..].try_into().expect("content is 80 bytes")
+	}
 
-	pub fn proof(&self) -> [u8; 48] { self.content[..48].try_into().expect("content is 80 bytes") }
+	pub fn proof(&self) -> [u8; 48] {
+		self.content[..48].try_into().expect("content is 80 bytes")
+	}
 }
 
 impl From<Cell> for DataCell {

--- a/kate/recovery/src/matrix.rs
+++ b/kate/recovery/src/matrix.rs
@@ -50,16 +50,24 @@ pub struct Dimensions {
 impl Dimensions {
 	/// Creates new matrix dimensions.
 	/// Data layout is assumed to be row-wise.
-	pub const fn new(rows: u16, cols: u16) -> Self { Dimensions { rows, cols } }
+	pub const fn new(rows: u16, cols: u16) -> Self {
+		Dimensions { rows, cols }
+	}
 
 	/// Matrix size.
-	pub fn size(&self) -> u32 { self.rows as u32 * self.cols as u32 }
+	pub fn size(&self) -> u32 {
+		self.rows as u32 * self.cols as u32
+	}
 
 	/// Extended matrix size.
-	pub fn extended_size(&self) -> u32 { self.extended_rows() * self.cols as u32 }
+	pub fn extended_size(&self) -> u32 {
+		self.extended_rows() * self.cols as u32
+	}
 
 	/// Extended matrix rows count.
-	pub fn extended_rows(&self) -> u32 { (self.rows as u32) * EXTENSION_FACTOR_U32 }
+	pub fn extended_rows(&self) -> u32 {
+		(self.rows as u32) * EXTENSION_FACTOR_U32
+	}
 
 	/// List of data row indexes in the extended matrix.
 	pub fn extended_data_rows(&self, cells: Range<u32>) -> Vec<u32> {
@@ -74,7 +82,9 @@ impl Dimensions {
 	}
 
 	/// Column index of a cell in the matrix.
-	fn col(&self, cell: u32) -> u16 { (cell % self.cols as u32) as u16 }
+	fn col(&self, cell: u32) -> u16 {
+		(cell % self.cols as u32) as u16
+	}
 
 	/// Extended matrix data row index of cell in the data matrix.
 	fn extended_data_row(&self, cell: u32) -> u32 {
@@ -103,7 +113,9 @@ impl Dimensions {
 	}
 
 	/// Creates iterator over rows in extended matrix.
-	pub fn iter_extended_rows(&self) -> impl Iterator<Item = u32> { 0..self.extended_rows() }
+	pub fn iter_extended_rows(&self) -> impl Iterator<Item = u32> {
+		0..self.extended_rows()
+	}
 
 	/// Creates iterator over data cells in data matrix (used to retrieve data from the matrix).
 	pub fn iter_data(&self) -> impl Iterator<Item = (usize, usize)> {

--- a/kate/src/com.rs
+++ b/kate/src/com.rs
@@ -53,7 +53,9 @@ pub enum Error {
 }
 
 impl From<PlonkError> for Error {
-	fn from(error: PlonkError) -> Self { Self::PlonkError(error) }
+	fn from(error: PlonkError) -> Self {
+		Self::PlonkError(error)
+	}
 }
 
 pub type XtsLayout = Vec<(AppId, u32)>;
@@ -850,11 +852,14 @@ mod tests {
 		)
 		.unwrap();
 
-		assert_eq!(dimensions, BlockDimensions {
-			rows: 1.into(),
-			cols: 4.into(),
-			chunk_size: 32
-		});
+		assert_eq!(
+			dimensions,
+			BlockDimensions {
+				rows: 1.into(),
+				cols: 4.into(),
+				chunk_size: 32
+			}
+		);
 		let expected_commitments = hex!("960F08F97D3A8BD21C3F5682366130132E18E375A587A1E5900937D7AA5F33C4E20A1C0ACAE664DCE1FD99EDC2693B8D960F08F97D3A8BD21C3F5682366130132E18E375A587A1E5900937D7AA5F33C4E20A1C0ACAE664DCE1FD99EDC2693B8D");
 		assert_eq!(commitments, expected_commitments);
 	}
@@ -1124,5 +1129,7 @@ Let's see how this gets encoded and then reconstructed by sampling only some dat
 
 	#[test_case( r#"{ "row": 42, "col": 99 }"# => Cell::new(42.into(),99.into()) ; "Simple" )]
 	#[test_case( r#"{ "row": 4294967295, "col": 99 }"# => Cell::new(4_294_967_295.into(),99.into()) ; "Max row" )]
-	fn serde_block_length_types_untagged(data: &str) -> Cell { serde_json::from_str(data).unwrap() }
+	fn serde_block_length_types_untagged(data: &str) -> Cell {
+		serde_json::from_str(data).unwrap()
+	}
 }

--- a/primitives/avail/src/asdr.rs
+++ b/primitives/avail/src/asdr.rs
@@ -41,15 +41,23 @@ pub struct AppId(#[codec(compact)] pub u32);
 
 #[cfg(feature = "std")]
 impl MallocSizeOf for AppId {
-	fn size_of(&self, ops: &mut MallocSizeOfOps) -> usize { self.0.size_of(ops) }
+	fn size_of(&self, ops: &mut MallocSizeOfOps) -> usize {
+		self.0.size_of(ops)
+	}
 }
 
 impl Zero for AppId {
-	fn zero() -> Self { 0u32.into() }
+	fn zero() -> Self {
+		0u32.into()
+	}
 
-	fn is_zero(&self) -> bool { self.0 == 0u32 }
+	fn is_zero(&self) -> bool {
+		self.0 == 0u32
+	}
 
-	fn set_zero(&mut self) { self.0 = 0u32; }
+	fn set_zero(&mut self) {
+		self.0 = 0u32;
+	}
 }
 
 /// Raw Extrinsic with application id.
@@ -70,5 +78,7 @@ impl From<Vec<u8>> for AppExtrinsic {
 }
 
 impl GetAppId for AppExtrinsic {
-	fn app_id(&self) -> AppId { self.app_id }
+	fn app_id(&self) -> AppId {
+		self.app_id
+	}
 }

--- a/primitives/avail/src/asdr/app_unchecked_extrinsic.rs
+++ b/primitives/avail/src/asdr/app_unchecked_extrinsic.rs
@@ -101,7 +101,9 @@ impl<Address, Call, Signature, Extra> MallocSizeOf
 where
 	Extra: SignedExtension,
 {
-	fn size_of(&self, _ops: &mut MallocSizeOfOps) -> usize { 0 }
+	fn size_of(&self, _ops: &mut MallocSizeOfOps) -> usize {
+		0
+	}
 }
 
 impl<Address, Call, Signature, Extra: SignedExtension>
@@ -130,7 +132,9 @@ impl<Address, Call, Signature, Extra: SignedExtension> Extrinsic
 	type Call = Call;
 	type SignaturePayload = (Address, Signature, Extra);
 
-	fn is_signed(&self) -> Option<bool> { Some(self.signature.is_some()) }
+	fn is_signed(&self) -> Option<bool> {
+		Some(self.signature.is_some())
+	}
 
 	fn new(function: Call, signed_data: Option<Self::SignaturePayload>) -> Option<Self> {
 		Some(if let Some((address, signature, extra)) = signed_data {
@@ -202,7 +206,9 @@ where
 	Call: GetDispatchInfo,
 	Extra: SignedExtension,
 {
-	fn get_dispatch_info(&self) -> DispatchInfo { self.function.get_dispatch_info() }
+	fn get_dispatch_info(&self) -> DispatchInfo {
+		self.function.get_dispatch_info()
+	}
 }
 
 /// A payload that has been signed for an unchecked extrinsics.
@@ -247,7 +253,9 @@ where
 	}
 
 	/// Deconstruct the payload into it's components.
-	pub fn deconstruct(self) -> (Call, Extra, Extra::AdditionalSigned) { self.0 }
+	pub fn deconstruct(self) -> (Call, Extra, Extra::AdditionalSigned) {
+		self.0
+	}
 }
 
 impl<Call, Extra> Encode for SignedPayload<Call, Extra>
@@ -419,7 +427,9 @@ impl<Address, Call, Signature, Extra> ExtrinsicCall
 where
 	Extra: SignedExtension,
 {
-	fn call(&self) -> &Self::Call { &self.function }
+	fn call(&self) -> &Self::Call {
+		&self.function
+	}
 }
 
 impl<Address, Call, Signature, Extra> From<AppUncheckedExtrinsic<Address, Call, Signature, Extra>>
@@ -474,7 +484,9 @@ mod tests {
 	}
 
 	impl GetAppId for TestExtra {
-		fn app_id(&self) -> AppId { Default::default() }
+		fn app_id(&self) -> AppId {
+			Default::default()
+		}
 	}
 
 	type Ex = AppUncheckedExtrinsic<TestAccountId, TestCall, TestSig, TestExtra>;

--- a/primitives/avail/src/asdr/get_app_id.rs
+++ b/primitives/avail/src/asdr/get_app_id.rs
@@ -2,11 +2,15 @@ use crate::asdr::AppId;
 
 /// Get application Id trait
 pub trait GetAppId {
-	fn app_id(&self) -> AppId { Default::default() }
+	fn app_id(&self) -> AppId {
+		Default::default()
+	}
 }
 
 impl<A, B, C, D, E, F, G, H: GetAppId> GetAppId for (A, B, C, D, E, F, G, H) {
-	fn app_id(&self) -> AppId { self.7.app_id() }
+	fn app_id(&self) -> AppId {
+		self.7.app_id()
+	}
 }
 
 #[cfg(test)]
@@ -17,7 +21,9 @@ mod tests {
 	struct CustomAppId {}
 
 	impl GetAppId for CustomAppId {
-		fn app_id(&self) -> AppId { 7.into() }
+		fn app_id(&self) -> AppId {
+			7.into()
+		}
 	}
 
 	struct DefaultGetAppId {}

--- a/primitives/avail/src/data_proof.rs
+++ b/primitives/avail/src/data_proof.rs
@@ -13,7 +13,9 @@ use thiserror_no_std::Error;
 pub struct HasherSha256 {}
 
 impl Hasher for HasherSha256 {
-	fn hash(data: &[u8]) -> Hash { sha2_256(data) }
+	fn hash(data: &[u8]) -> Hash {
+		sha2_256(data)
+	}
 }
 
 /// Wrapper of `beefy-merkle-tree::MerkleProof` with codec support.

--- a/primitives/avail/src/header/extension/mod.rs
+++ b/primitives/avail/src/header/extension/mod.rs
@@ -42,11 +42,15 @@ macro_rules! forward_to_version {
 }
 
 impl HeaderExtension {
-	pub fn data_root(&self) -> H256 { forward_to_version!(self, data_root) }
+	pub fn data_root(&self) -> H256 {
+		forward_to_version!(self, data_root)
+	}
 }
 
 impl Default for HeaderExtension {
-	fn default() -> Self { v1::HeaderExtension::default().into() }
+	fn default() -> Self {
+		v1::HeaderExtension::default().into()
+	}
 }
 
 #[cfg(feature = "std")]
@@ -58,11 +62,15 @@ impl MallocSizeOf for HeaderExtension {
 
 impl From<v1::HeaderExtension> for HeaderExtension {
 	#[inline]
-	fn from(ext: v1::HeaderExtension) -> Self { Self::V1(ext) }
+	fn from(ext: v1::HeaderExtension) -> Self {
+		Self::V1(ext)
+	}
 }
 
 #[cfg(feature = "header-backward-compatibility-test")]
 impl From<v_test::HeaderExtension> for HeaderExtension {
 	#[inline]
-	fn from(ext: v_test::HeaderExtension) -> Self { Self::VTest(ext) }
+	fn from(ext: v_test::HeaderExtension) -> Self {
+		Self::VTest(ext)
+	}
 }

--- a/primitives/avail/src/header/extension/v1.rs
+++ b/primitives/avail/src/header/extension/v1.rs
@@ -16,7 +16,9 @@ pub struct HeaderExtension {
 }
 
 impl HeaderExtension {
-	pub fn data_root(&self) -> H256 { self.commitment.data_root }
+	pub fn data_root(&self) -> H256 {
+		self.commitment.data_root
+	}
 }
 
 #[cfg(feature = "std")]

--- a/primitives/avail/src/header/extension/v_test.rs
+++ b/primitives/avail/src/header/extension/v_test.rs
@@ -18,7 +18,9 @@ pub struct HeaderExtension {
 }
 
 impl HeaderExtension {
-	pub fn data_root(&self) -> H256 { self.commitment.data_root }
+	pub fn data_root(&self) -> H256 {
+		self.commitment.data_root
+	}
 }
 
 #[cfg(feature = "std")]

--- a/primitives/avail/src/header/mod.rs
+++ b/primitives/avail/src/header/mod.rs
@@ -93,7 +93,9 @@ impl<N: HeaderBlockNumber, H: HeaderHash> Header<N, H> {
 	/// Convenience helper for computing the hash of the header without having
 	/// to import the trait.
 	#[inline]
-	pub fn hash(&self) -> H::Output { H::hash_of(self) }
+	pub fn hash(&self) -> H::Output {
+		H::hash_of(self)
+	}
 }
 
 impl<N, H> Default for Header<N, H>
@@ -163,23 +165,41 @@ where
 	type Hashing = Hash;
 	type Number = Number;
 
-	fn number(&self) -> &Self::Number { &self.number }
+	fn number(&self) -> &Self::Number {
+		&self.number
+	}
 
-	fn set_number(&mut self, num: Self::Number) { self.number = num }
+	fn set_number(&mut self, num: Self::Number) {
+		self.number = num
+	}
 
-	fn extrinsics_root(&self) -> &Self::Hash { &self.extrinsics_root }
+	fn extrinsics_root(&self) -> &Self::Hash {
+		&self.extrinsics_root
+	}
 
-	fn set_extrinsics_root(&mut self, root: Self::Hash) { self.extrinsics_root = root }
+	fn set_extrinsics_root(&mut self, root: Self::Hash) {
+		self.extrinsics_root = root
+	}
 
-	fn state_root(&self) -> &Self::Hash { &self.state_root }
+	fn state_root(&self) -> &Self::Hash {
+		&self.state_root
+	}
 
-	fn set_state_root(&mut self, root: Self::Hash) { self.state_root = root }
+	fn set_state_root(&mut self, root: Self::Hash) {
+		self.state_root = root
+	}
 
-	fn parent_hash(&self) -> &Self::Hash { &self.parent_hash }
+	fn parent_hash(&self) -> &Self::Hash {
+		&self.parent_hash
+	}
 
-	fn set_parent_hash(&mut self, hash: Self::Hash) { self.parent_hash = hash }
+	fn set_parent_hash(&mut self, hash: Self::Hash) {
+		self.parent_hash = hash
+	}
 
-	fn digest(&self) -> &Digest { &self.digest }
+	fn digest(&self) -> &Digest {
+		&self.digest
+	}
 
 	fn digest_mut(&mut self) -> &mut Digest {
 		#[cfg(feature = "std")]
@@ -221,9 +241,13 @@ impl<N: HeaderBlockNumber, H: HeaderHash> ExtendedHeader for Header<N, H> {
 		Header::<N, H>::new(n, extrinsics, state, parent, digest, extension)
 	}
 
-	fn extension(&self) -> &HeaderExtension { &self.extension }
+	fn extension(&self) -> &HeaderExtension {
+		&self.extension
+	}
 
-	fn set_extension(&mut self, extension: HeaderExtension) { self.extension = extension; }
+	fn set_extension(&mut self, extension: HeaderExtension) {
+		self.extension = extension;
+	}
 }
 
 #[cfg(test)]
@@ -325,7 +349,9 @@ mod tests {
 	}
 
 	#[cfg(not(feature = "header-backward-compatibility-test"))]
-	fn header_test() -> Header<u32, BlakeTwo256> { header_v1() }
+	fn header_test() -> Header<u32, BlakeTwo256> {
+		header_v1()
+	}
 
 	#[cfg(feature = "header-backward-compatibility-test")]
 	fn header_test() -> Header<u32, BlakeTwo256> {

--- a/primitives/avail/src/lib.rs
+++ b/primitives/avail/src/lib.rs
@@ -104,7 +104,9 @@ pub struct BlockLengthColumns(#[codec(compact)] pub u32);
 
 impl BlockLengthColumns {
 	#[inline]
-	pub fn as_usize(&self) -> usize { self.0 as usize }
+	pub fn as_usize(&self) -> usize {
+		self.0 as usize
+	}
 }
 
 /// Strong type for `BlockLength::rows`
@@ -132,5 +134,7 @@ pub struct BlockLengthRows(#[codec(compact)] pub u32);
 
 impl BlockLengthRows {
 	#[inline]
-	pub fn as_usize(&self) -> usize { self.0 as usize }
+	pub fn as_usize(&self) -> usize {
+		self.0 as usize
+	}
 }

--- a/primitives/nomad/merkle/src/light.rs
+++ b/primitives/nomad/merkle/src/light.rs
@@ -53,7 +53,9 @@ impl<const N: usize> Merkle for LightMerkle<N> {
 		2u32.saturating_pow(N as u32)
 	}
 
-	fn count(&self) -> u32 { self.count }
+	fn count(&self) -> u32 {
+		self.count
+	}
 
 	fn root(&self) -> H256 {
 		let mut node: H256 = Default::default();
@@ -72,7 +74,9 @@ impl<const N: usize> Merkle for LightMerkle<N> {
 		node
 	}
 
-	fn depth(&self) -> usize { N }
+	fn depth(&self) -> usize {
+		N
+	}
 
 	fn ingest(&mut self, element: H256) -> Result<H256, TreeError> {
 		ensure!(Self::max_elements() > self.count, TreeError::MerkleTreeFull);
@@ -107,13 +111,19 @@ impl<const N: usize> LightMerkle<N> {
 	}
 
 	/// Calculate the initital root of a tree of this depth
-	pub fn initial_root() -> H256 { LightMerkle::<N>::default().root() }
+	pub fn initial_root() -> H256 {
+		LightMerkle::<N>::default().root()
+	}
 
 	/// Get the leading-edge branch.
-	pub fn branch(&self) -> &[H256; N] { &self.branch }
+	pub fn branch(&self) -> &[H256; N] {
+		&self.branch
+	}
 
 	/// Verify a incremental merkle proof of inclusion
-	pub fn verify(&self, proof: &Proof<N>) -> bool { proof.root() == self.root() }
+	pub fn verify(&self, proof: &Proof<N>) -> bool {
+		proof.root() == self.root()
+	}
 }
 
 #[cfg(feature = "std")]

--- a/primitives/nomad/merkle/src/proof.rs
+++ b/primitives/nomad/merkle/src/proof.rs
@@ -54,5 +54,7 @@ mod const_array_serde {
 
 impl<const N: usize> MerkleProof for Proof<N> {
 	/// Calculate the merkle root produced by evaluating the proof
-	fn root(&self) -> H256 { merkle_root_from_branch(self.leaf, &self.path, self.index) }
+	fn root(&self) -> H256 {
+		merkle_root_from_branch(self.leaf, &self.path, self.index)
+	}
 }

--- a/primitives/nomad/nomad-base/src/lib.rs
+++ b/primitives/nomad/nomad-base/src/lib.rs
@@ -44,7 +44,9 @@ impl NomadBase {
 		}
 	}
 
-	pub fn home_domain_hash(&self) -> H256 { home_domain_hash(self.local_domain) }
+	pub fn home_domain_hash(&self) -> H256 {
+		home_domain_hash(self.local_domain)
+	}
 
 	pub fn set_committed_root(&mut self, new_committed_root: H256) {
 		self.committed_root = new_committed_root;

--- a/primitives/nomad/nomad-core/src/state.rs
+++ b/primitives/nomad/nomad-core/src/state.rs
@@ -12,5 +12,7 @@ pub enum NomadState {
 }
 
 impl Default for NomadState {
-	fn default() -> Self { Self::Active }
+	fn default() -> Self {
+		Self::Active
+	}
 }

--- a/primitives/nomad/nomad-core/src/test_utils.rs
+++ b/primitives/nomad/nomad-core/src/test_utils.rs
@@ -15,9 +15,13 @@ pub struct Updater {
 }
 
 impl Updater {
-	pub const fn new(domain: u32, signer: LocalWallet) -> Self { Self { domain, signer } }
+	pub const fn new(domain: u32, signer: LocalWallet) -> Self {
+		Self { domain, signer }
+	}
 
-	pub fn address(&self) -> H160 { self.signer.address().0.into() }
+	pub fn address(&self) -> H160 {
+		self.signer.address().0.into()
+	}
 
 	fn sign_message_without_eip_155<M: Send + Sync + AsRef<[u8]>>(&self, message: M) -> Signature {
 		// Had to reimplement hash and signing to remove async-ness for

--- a/primitives/nomad/nomad-core/src/typed_message.rs
+++ b/primitives/nomad/nomad-core/src/typed_message.rs
@@ -19,9 +19,13 @@ where
 	const MESSAGE_TYPE: u8;
 
 	/// Size of encoded struct (+ 1 for u8 type tag)
-	fn len(&self) -> usize { mem::size_of::<Self>() + 1 }
+	fn len(&self) -> usize {
+		mem::size_of::<Self>() + 1
+	}
 
-	fn is_empty(&self) -> bool { self.len() == 0 }
+	fn is_empty(&self) -> bool {
+		self.len() == 0
+	}
 
 	/// Encode self into `BoundedVec<u8, S>`
 	fn encode(&self) -> Vec<u8>;

--- a/primitives/nomad/nomad-core/src/update.rs
+++ b/primitives/nomad/nomad-core/src/update.rs
@@ -28,7 +28,9 @@ impl Update {
 		)
 	}
 
-	fn prepended_hash(&self) -> H256 { hash_message(self.signing_hash()) }
+	fn prepended_hash(&self) -> H256 {
+		hash_message(self.signing_hash())
+	}
 }
 
 /// A Signed Nomad Update
@@ -42,9 +44,13 @@ pub struct SignedUpdate {
 }
 
 impl SignedUpdate {
-	pub fn previous_root(&self) -> H256 { self.update.previous_root }
+	pub fn previous_root(&self) -> H256 {
+		self.update.previous_root
+	}
 
-	pub fn new_root(&self) -> H256 { self.update.new_root }
+	pub fn new_root(&self) -> H256 {
+		self.update.new_root
+	}
 
 	/// Recover the Ethereum address of the signer
 	pub fn recover(&self) -> Result<H160, SignatureError> {

--- a/primitives/nomad/nomad-core/src/update_v2.rs
+++ b/primitives/nomad/nomad-core/src/update_v2.rs
@@ -24,7 +24,9 @@ impl UpdateV2 {
 		keccak256_concat!(home_domain_hash(self.home_domain), self.root)
 	}
 
-	fn prepended_hash(&self) -> H256 { hash_message(self.signing_hash()) }
+	fn prepended_hash(&self) -> H256 {
+		hash_message(self.signing_hash())
+	}
 }
 
 /// A Signed Nomad Update

--- a/primitives/nomad/nomad-core/src/utils.rs
+++ b/primitives/nomad/nomad-core/src/utils.rs
@@ -9,7 +9,9 @@ pub fn home_domain_hash(home_domain: u32) -> H256 {
 }
 
 /// Hash a message according to EIP-191 with the ethereum signed message prefix.
-pub fn to_eth_signed_message_hash(hash: &H256) -> H256 { keccak256_concat!(ETH_PREFIX, hash) }
+pub fn to_eth_signed_message_hash(hash: &H256) -> H256 {
+	keccak256_concat!(ETH_PREFIX, hash)
+}
 
 /// Destination and destination-specific nonce combined in single field (
 /// (destination << 32) & nonce)

--- a/primitives/nomad/signature/src/signature.rs
+++ b/primitives/nomad/signature/src/signature.rs
@@ -143,7 +143,9 @@ impl Signature {
 
 	/// Copies and serializes `self` into a new `Vec` with the recovery id included
 	#[allow(clippy::wrong_self_convention)]
-	pub fn to_vec(&self) -> Vec<u8> { self.into() }
+	pub fn to_vec(&self) -> Vec<u8> {
+		self.into()
+	}
 }
 
 fn normalize_recovery_id(v: u64) -> u8 {
@@ -215,39 +217,57 @@ impl From<&Signature> for [u8; 65] {
 }
 
 impl From<Signature> for [u8; 65] {
-	fn from(src: Signature) -> [u8; 65] { <[u8; 65]>::from(&src) }
+	fn from(src: Signature) -> [u8; 65] {
+		<[u8; 65]>::from(&src)
+	}
 }
 
 impl From<&Signature> for Vec<u8> {
-	fn from(src: &Signature) -> Vec<u8> { <[u8; 65]>::from(src).to_vec() }
+	fn from(src: &Signature) -> Vec<u8> {
+		<[u8; 65]>::from(src).to_vec()
+	}
 }
 
 impl From<Signature> for Vec<u8> {
-	fn from(src: Signature) -> Vec<u8> { <[u8; 65]>::from(&src).to_vec() }
+	fn from(src: Signature) -> Vec<u8> {
+		<[u8; 65]>::from(&src).to_vec()
+	}
 }
 
 impl From<&[u8]> for RecoveryMessage {
-	fn from(s: &[u8]) -> Self { s.to_owned().into() }
+	fn from(s: &[u8]) -> Self {
+		s.to_owned().into()
+	}
 }
 
 impl From<Vec<u8>> for RecoveryMessage {
-	fn from(s: Vec<u8>) -> Self { RecoveryMessage::Data(s) }
+	fn from(s: Vec<u8>) -> Self {
+		RecoveryMessage::Data(s)
+	}
 }
 
 impl From<&str> for RecoveryMessage {
-	fn from(s: &str) -> Self { s.as_bytes().to_owned().into() }
+	fn from(s: &str) -> Self {
+		s.as_bytes().to_owned().into()
+	}
 }
 
 impl From<String> for RecoveryMessage {
-	fn from(s: String) -> Self { RecoveryMessage::Data(s.into_bytes()) }
+	fn from(s: String) -> Self {
+		RecoveryMessage::Data(s.into_bytes())
+	}
 }
 
 impl From<[u8; 32]> for RecoveryMessage {
-	fn from(hash: [u8; 32]) -> Self { H256(hash).into() }
+	fn from(hash: [u8; 32]) -> Self {
+		H256(hash).into()
+	}
 }
 
 impl From<H256> for RecoveryMessage {
-	fn from(hash: H256) -> Self { RecoveryMessage::Hash(hash) }
+	fn from(hash: H256) -> Self {
+		RecoveryMessage::Hash(hash)
+	}
 }
 
 #[cfg(feature = "std")]


### PR DESCRIPTION
Due to change to stable rust version, nightly `fmt` features are not available anymore. This PR adds `cargo fmt --check` step in the default github workflow, removes nightly features from `.rustfmt.toml`, and formats source code.