### PR TITLE
Prevent zero dimensions

### DIFF
--- a/kate/recovery/src/com.rs
+++ b/kate/recovery/src/com.rs
@@ -138,11 +138,11 @@ fn reconstruct_available(
 ) -> Result<Vec<u8>, ReconstructionError> {
 	let columns = map_cells(dimensions, cells)?;
 
-	let scalars = (0..dimensions.cols)
+	let scalars = (0..dimensions.cols())
 		.map(|col| match columns.get(&col) {
-			None => Ok(vec![None; dimensions.rows as usize]),
+			None => Ok(vec![None; dimensions.rows() as usize]),
 			Some(column_cells) => {
-				if column_cells.len() < dimensions.rows as usize {
+				if column_cells.len() < dimensions.rows() as usize {
 					return Err(ReconstructionError::InvalidColumn(col));
 				}
 				let cells = column_cells.values().cloned().collect::<Vec<_>>();
@@ -526,7 +526,7 @@ mod tests {
 			size: 16,
 			index: vec![(1, 2), (2, 5), (3, 8)],
 		};
-		let dimensions = Dimensions::new(8, 4);
+		let dimensions = Dimensions::new(8, 4).unwrap();
 		let result = app_specific_rows(&index, &dimensions, app_id);
 		assert_eq!(expected.len(), result.len());
 	}
@@ -539,7 +539,7 @@ mod tests {
 			size: 8,
 			index: vec![(1, 5)],
 		};
-		let dimensions = Dimensions::new(4, 4);
+		let dimensions = Dimensions::new(4, 4).unwrap();
 		let result = app_specific_cells(&index, &dimensions, app_id).unwrap_or_default();
 		assert_eq!(expected.len(), result.len());
 		result.iter().zip(expected).for_each(|(a, &(row, col))| {

--- a/kate/recovery/src/commitments.rs
+++ b/kate/recovery/src/commitments.rs
@@ -122,8 +122,8 @@ pub fn verify_equality(
 		return Err(Error::InvalidData(DataError::RowAndCommitmentsMismatch));
 	}
 
-	let (prover_key, _) = public_params.trim(dimension.cols as usize)?;
-	let domain = EvaluationDomain::new(dimension.cols as usize)?;
+	let (prover_key, _) = public_params.trim(dimension.cols() as usize)?;
+	let domain = EvaluationDomain::new(dimension.cols() as usize)?;
 
 	// This is a single-threaded implementation.
 	// At some point we should benchmark and decide

--- a/kate/src/com.rs
+++ b/kate/src/com.rs
@@ -83,7 +83,7 @@ pub fn scalars_to_rows(
 	data: &[BlsScalar],
 ) -> Vec<Option<Vec<u8>>> {
 	let extended_rows = BlockLengthRows(dimensions.extended_rows());
-	let cols = BlockLengthColumns(dimensions.cols as u32);
+	let cols = BlockLengthColumns(dimensions.cols() as u32);
 	let app_rows = app_specific_rows(index, dimensions, app_id);
 	dimensions
 		.iter_extended_rows()
@@ -255,7 +255,7 @@ pub fn par_extend_data_matrix(
 ) -> Result<Vec<BlsScalar>, Error> {
 	let start = Instant::now();
 	let dimensions: matrix::Dimensions = block_dims.try_into().map_err(|_| Error::BlockTooBig)?;
-	let rows_num: usize = dimensions.rows.into();
+	let rows_num: usize = dimensions.rows().into();
 	let extended_rows_num = BlockLengthRows(dimensions.extended_rows());
 	let chunks = block.par_chunks_exact(block_dims.chunk_size as usize);
 	assert!(chunks.remainder().is_empty());

--- a/kate/src/lib.rs
+++ b/kate/src/lib.rs
@@ -101,15 +101,27 @@ impl BlockDimensions {
 	}
 }
 
+#[derive(PartialEq, Eq, Debug)]
+pub enum TryFromBlockDimensionsError {
+	InvalidRowsOrColumns(sp_std::num::TryFromIntError),
+	InvalidDimensions,
+}
+
+impl From<sp_std::num::TryFromIntError> for TryFromBlockDimensionsError {
+	fn from(error: sp_std::num::TryFromIntError) -> Self {
+		TryFromBlockDimensionsError::InvalidRowsOrColumns(error)
+	}
+}
+
 #[cfg(feature = "std")]
 impl sp_std::convert::TryInto<Dimensions> for BlockDimensions {
-	type Error = sp_std::num::TryFromIntError;
+	type Error = TryFromBlockDimensionsError;
 
 	fn try_into(self) -> Result<Dimensions, Self::Error> {
 		let rows = self.rows.0.try_into()?;
 		let cols = self.cols.0.try_into()?;
 
-		Ok(Dimensions { rows, cols })
+		Dimensions::new(rows, cols).ok_or(TryFromBlockDimensionsError::InvalidDimensions)
 	}
 }
 


### PR DESCRIPTION
If matrix dimensions has zero rows or cols, some functions could panic due to division by zero. Since its to complex to introduce full type safety with non-zero integers, runtime check on dimensions construction is performed. Since rows and cols are private, its not possible to construct invalid dimensions outside of module.