### PR TITLE
Replace logs by metrics on Kate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1774,7 +1774,7 @@ dependencies = [
 
 [[package]]
 name = "kate"
-version = "0.6.2"
+version = "0.7.0"
 dependencies = [
  "criterion",
  "da-primitives",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1774,7 +1774,7 @@ dependencies = [
 
 [[package]]
 name = "kate"
-version = "0.6.1"
+version = "0.6.2"
 dependencies = [
  "criterion",
  "da-primitives",

--- a/kate/Cargo.toml
+++ b/kate/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "kate"
-version = "0.6.2"
+version = "0.7.0"
 authors = ["Denis Ermolin <denis.ermolin@matic.network>"]
 edition = "2021"
 

--- a/kate/Cargo.toml
+++ b/kate/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "kate"
-version = "0.6.1"
+version = "0.6.2"
 authors = ["Denis Ermolin <denis.ermolin@matic.network>"]
 edition = "2021"
 

--- a/kate/recovery/src/com.rs
+++ b/kate/recovery/src/com.rs
@@ -270,7 +270,7 @@ pub fn decode_app_extrinsics(
 			.filter(|cell| !cell.data.is_empty())
 		{
 			None => app_data.extend(vec![0; config::CHUNK_SIZE]),
-			Some(cell) => app_data.extend(&cell.data),
+			Some(cell) => app_data.extend(cell.data),
 		}
 	}
 	let ranges = index.app_data_ranges(app_id);
@@ -398,7 +398,7 @@ fn zero_poly_fn(
 	let mut zero_poly: Vec<BlsScalar> = Vec::with_capacity(length as usize);
 	let mut sub: BlsScalar;
 	for i in 0..missing_indices.len() {
-		let v = missing_indices[i as usize];
+		let v = missing_indices[i];
 		sub = BlsScalar::zero() - expanded_r_o_u[(v * domain_stride) as usize];
 		zero_poly.push(sub);
 		if i > 0 {

--- a/kate/recovery/src/matrix.rs
+++ b/kate/recovery/src/matrix.rs
@@ -177,7 +177,7 @@ impl Dimensions {
 
 	/// Checks if extended matrix contains given position.
 	pub fn extended_contains(&self, position: &Position) -> bool {
-		(position.row as u32) < self.extended_rows() && position.col < self.cols
+		position.row < self.extended_rows() && position.col < self.cols
 	}
 
 	/// Creates iterator over rows in extended matrix.

--- a/kate/src/lib.rs
+++ b/kate/src/lib.rs
@@ -62,6 +62,8 @@ pub mod testnet {
 	}
 }
 
+pub mod metrics;
+
 #[cfg(feature = "std")]
 pub mod com;
 /// Precalculate the length of padding IEC 9797 1.

--- a/kate/src/metrics.rs
+++ b/kate/src/metrics.rs
@@ -1,0 +1,24 @@
+use crate::BlockDimensions;
+use sp_std::time::Duration;
+
+/// Trait for measurements during the header built process.
+pub trait Metrics {
+	fn extended_block_time(&self, elapsed: Duration);
+	fn preparation_block_time(&self, elapsed: Duration);
+	fn commitment_build_time(&self, elapsed: Duration);
+	fn proof_build_time(&self, elapsed: Duration, cells: u32);
+	fn block_dims_and_size(&self, block_dims: &BlockDimensions, block_len: u32);
+}
+
+/// Adapter to ignore any measurements.
+/// It should be used for testing environments.
+#[derive(Clone, Copy, Debug)]
+pub struct IgnoreMetrics {}
+
+impl Metrics for IgnoreMetrics {
+	fn extended_block_time(&self, _: Duration) {}
+	fn preparation_block_time(&self, _: Duration) {}
+	fn commitment_build_time(&self, _: Duration) {}
+	fn proof_build_time(&self, _: Duration, _: u32) {}
+	fn block_dims_and_size(&self, _: &BlockDimensions, _: u32) {}
+}


### PR DESCRIPTION
It replaces `logs` by metrics which will be pushed into `Prometheus` in the node.