### PR TITLE
Fix `Extrinsics` codification

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -818,7 +818,7 @@ dependencies = [
 
 [[package]]
 name = "da-primitives"
-version = "0.4.3"
+version = "0.4.4"
 dependencies = [
  "beefy-merkle-tree",
  "derive_more",

--- a/primitives/avail/Cargo.toml
+++ b/primitives/avail/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "da-primitives"
-version = "0.4.3"
+version = "0.4.4"
 authors = []
 edition = "2018"
 

--- a/primitives/avail/src/asdr/app_unchecked_extrinsic.rs
+++ b/primitives/avail/src/asdr/app_unchecked_extrinsic.rs
@@ -390,11 +390,12 @@ where
 impl<Address: Encode, Signature: Encode, Call: Encode, Extra: SignedExtension> serde::Serialize
 	for AppUncheckedExtrinsic<Address, Call, Signature, Extra>
 {
-	fn serialize<S>(&self, seq: S) -> Result<S::Ok, S::Error>
+	fn serialize<S>(&self, s: S) -> Result<S::Ok, S::Error>
 	where
 		S: ::serde::Serializer,
 	{
-		self.using_encoded(|bytes| seq.serialize_bytes(bytes))
+		let encoded = self.encode();
+		sp_core::bytes::serialize(&encoded, s)
 	}
 }
 


### PR DESCRIPTION
It fixes the serialization of `AppUncheckedExtrinsic`, in order to be aligned with expected format from `subxt`.